### PR TITLE
Backup history proof of concept

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,9 @@
+[main]
+
+ignore-patterns=(_version.py|test_(.*).py|conftest.py)
+
+enable =
+    logging-not-lazy
+
+disable =
+    logging-fstring-interpolation

--- a/gsb/_git.py
+++ b/gsb/_git.py
@@ -3,12 +3,12 @@ import datetime as dt
 import getpass
 import socket
 from pathlib import Path
-from typing import Iterable, NamedTuple
+from typing import Iterable, NamedTuple, Self
 
 import pygit2
 
 
-def init(repo_root: Path) -> None:
+def init(repo_root: Path) -> pygit2.Repository:
     """Initialize (or re-initialize) a git repo, equivalent to running
     `git init`
 
@@ -17,12 +17,17 @@ def init(repo_root: Path) -> None:
     repo_root : Path
         The root directory of the git repo
 
+    Returns
+    -------
+    repo
+        The initialized git repository
+
     Raises
     ------
     OSError
         If `repo_root` does not exist, is not a directory or cannot be accessed
     """
-    _repo(repo_root, new=True)
+    return _repo(repo_root, new=True)
 
 
 def _repo(repo_root: Path, new: bool = False) -> pygit2.Repository:
@@ -92,7 +97,7 @@ def _git_config() -> dict[str, str]:  # pragma: no cover
         return {}
 
 
-def add(repo_root: Path, patterns: Iterable[str]) -> None:
+def add(repo_root: Path, patterns: Iterable[str]) -> pygit2.Index:
     """Add files matching the given pattern to the repo, equivalent to running
     `git add <pattern>`
 
@@ -103,6 +108,11 @@ def add(repo_root: Path, patterns: Iterable[str]) -> None:
     patterns : list of str
         The glob patterns to match
 
+    Returns
+    -------
+    index
+        The updated git index
+
     Raises
     ------
     OSError
@@ -111,9 +121,10 @@ def add(repo_root: Path, patterns: Iterable[str]) -> None:
     repo = _repo(repo_root)
     repo.index.add_all(list(patterns))
     repo.index.write()
+    return repo.index
 
 
-def force_add(repo_root: Path, files: Iterable[Path]) -> None:
+def force_add(repo_root: Path, files: Iterable[Path]) -> pygit2.Index:
     """Forcibly add specific files, overriding .gitignore, equivalent to running
     `git add <file> --force`
 
@@ -123,6 +134,11 @@ def force_add(repo_root: Path, files: Iterable[Path]) -> None:
         The root directory of the git repo
     files : list of paths
         The file paths to add, relative to the repo root
+
+    Returns
+    -------
+    index
+        The updated git index
 
     Raises
     ------
@@ -145,9 +161,12 @@ def force_add(repo_root: Path, files: Iterable[Path]) -> None:
             if "is a directory" in str(maybe_directory):
                 raise IsADirectoryError(maybe_directory)
     repo.index.write()
+    return repo.index
 
 
-def commit(repo_root: Path, message: str) -> None:
+def commit(
+    repo_root: Path, message: str, _committer: tuple[str, str] | None = None
+) -> pygit2.Object:
     """Commit staged changes, equivalent to running `git commit -m <message>`
 
     Parameters
@@ -156,6 +175,15 @@ def commit(repo_root: Path, message: str) -> None:
         The root directory of the git repo
     message : str
         The commit message
+    _committer : (str, str) tuple
+        By default this method uses "gsb" as the committer. This should not
+        be overridden outside of testing, but to do so, pass in both the
+        username and email address.
+
+    Returns
+    -------
+    commit
+        The generated commit object
 
     Raises
     ------
@@ -178,10 +206,16 @@ def commit(repo_root: Path, message: str) -> None:
 
     config = _config()
     author = pygit2.Signature(config["user.name"], config["user.email"])
-    committer = pygit2.Signature(config["committer.name"], config["committer.email"])
-    repo.create_commit(
+    if _committer is None:
+        committer = pygit2.Signature(
+            config["committer.name"], config["committer.email"]
+        )
+    else:
+        committer = pygit2.Signature(*_committer)
+    commit_id = repo.create_commit(
         ref, author, committer, message, repo.index.write_tree(), parents
     )
+    return repo[commit_id]
 
 
 class Commit(NamedTuple):
@@ -195,11 +229,28 @@ class Commit(NamedTuple):
         The commit message
     timestamp : dt.datetime
         The timestamp of the commit
+    gsb : bool
+        True if and only if the tag was created by `gsb`
     """
 
     hash: str
     message: str
     timestamp: dt.datetime
+    gsb: bool
+
+    @classmethod
+    def from_pygit2(cls, commit_object: pygit2.Object) -> Self:
+        """Resolve from a pygit2 object"""
+        try:
+            gsb = commit_object.committer.name == "gsb"
+        except AttributeError:
+            gsb = False
+        return cls(
+            commit_object.id,
+            commit_object.message,
+            dt.datetime.fromtimestamp(commit_object.commit_time),
+            gsb,
+        )
 
 
 def log(repo_root: Path, n: int) -> list[Commit]:
@@ -233,13 +284,7 @@ def log(repo_root: Path, n: int) -> list[Commit]:
     ):
         if i + 1 == n:
             break
-        history.append(
-            Commit(
-                commit_object.id,
-                commit_object.message,
-                dt.datetime.fromtimestamp(commit_object.commit_time),
-            )
-        )
+        history.append(Commit.from_pygit2(commit_object))
 
     return history
 
@@ -267,7 +312,12 @@ def ls_files(repo_root: Path) -> list[Path]:
     return [repo_root / file.path for file in repo.index]
 
 
-def tag(repo_root: Path, tag_name: str, annotation: str | None) -> None:
+def tag(
+    repo_root: Path,
+    tag_name: str,
+    annotation: str | None,
+    _tagger: tuple[str, str] | None = None,
+) -> pygit2.Object:
     """Create a tag at the current HEAD, equivalent to running
     `git tag [-am <annotation>]`
 
@@ -280,6 +330,15 @@ def tag(repo_root: Path, tag_name: str, annotation: str | None) -> None:
     annotation : str or None
         The annotation to give the tag. If None is provided, a lightweight tag
         will be created
+    _tagger : (str, str) tuple
+        By default this method uses "gsb" as the tagger. This should not
+        be overridden outside of testing, but to do so, pass in both the
+        username and email address.
+
+    Returns
+    -------
+    tag
+        The generated tag object
 
     Raises
     ------
@@ -291,7 +350,10 @@ def tag(repo_root: Path, tag_name: str, annotation: str | None) -> None:
     repo = _repo(repo_root)
 
     config = _config()
-    tagger = pygit2.Signature(config["committer.name"], config["committer.email"])
+    if _tagger is None:
+        tagger = pygit2.Signature(config["committer.name"], config["committer.email"])
+    else:
+        tagger = pygit2.Signature(*_tagger)
 
     if annotation:
         if not annotation.endswith("\n"):
@@ -304,8 +366,10 @@ def tag(repo_root: Path, tag_name: str, annotation: str | None) -> None:
             tagger,
             annotation,
         )
+        return repo.revparse_single(tag_name)
     else:
         repo.create_reference(f"refs/tags/{tag_name}", repo.head.target)
+        return repo.revparse_single(tag_name)
 
     # PSA: pygit2.AlreadyExistsError subclasses ValueError
 
@@ -319,11 +383,18 @@ class Tag(NamedTuple):
         The name of the tag
     annotation : str or None
         The tag's annotation. If None, then this is a lightweight tag
+    target : Commit
+        The commit the tag is targeting
+    gsb : bool or None
+        True if the tagger was  `gsb`, False if it was created by
+        someone / something else and None if it's a lightweight tag (which
+        doesn't have a tagger)
     """
 
     name: str
     annotation: str | None
-    # TODO : capture tagger as well for filtering to just gsb tags
+    target: Commit
+    gsb: bool | None
 
 
 def get_tags(repo_root: Path, annotated_only: bool) -> list[Tag]:
@@ -336,7 +407,7 @@ def get_tags(repo_root: Path, annotated_only: bool) -> list[Tag]:
     repo_root : Path
         The root directory of the git repo
     annotated_only : bool
-        Lightweight tags will be included if and only if this is `False`.
+        Lightweight tags will be included if and only if this is `False`
 
     Returns
     -------
@@ -348,15 +419,31 @@ def get_tags(repo_root: Path, annotated_only: bool) -> list[Tag]:
     OSError
         If `repo_root` does not exist, is not a directory or cannot be accessed
     """
-    # TODO: add ability to filter out non-gsb tags
     repo = _repo(repo_root)
     tags: list[Tag] = []
     for reference in repo.references.iterator(pygit2.GIT_REFERENCES_TAGS):
         tag_object = repo.revparse_single(reference.name)
         if tag_object.type == pygit2.GIT_OBJ_TAG:
-            tags.append(Tag(tag_object.name, tag_object.message))
-        if tag_object.type == pygit2.GIT_OBJ_COMMIT:
+            try:
+                gsb = tag_object.tagger.name == "gsb"
+            except AttributeError:
+                gsb = False
+            tags.append(
+                Tag(
+                    tag_object.name,
+                    tag_object.message,
+                    Commit.from_pygit2(repo[tag_object.target]),
+                    gsb,
+                )
+            )
+        elif tag_object.type == pygit2.GIT_OBJ_COMMIT:
             if annotated_only:
                 continue
-            tags.append(Tag(reference.shorthand, None))
+            tags.append(
+                Tag(reference.shorthand, None, Commit.from_pygit2(tag_object), False)
+            )
+        else:  # pragma: no cover
+            raise RuntimeError(
+                f"Don't know how to parse reference of type: {tag_object.type}"
+            )
     return sorted(tags)

--- a/gsb/history.py
+++ b/gsb/history.py
@@ -53,7 +53,7 @@ def get_history(
     Returns
     -------
     list of dict
-        Metadata on the requested revisions, sorted in reverse-chronological
+        metadata on the requested revisions, sorted in reverse-chronological
         order
     """
     raise NotImplementedError

--- a/gsb/history.py
+++ b/gsb/history.py
@@ -61,16 +61,12 @@ def get_history(
     OSError
         If the specified repo does not exist or is not a git repo
     """
-    # TODO: if performance requires it, implement _git.log to fetch m commits
-    #       at a time
-    commits = _git.log(repo_root, n=-1)
-
     tag_lookup = {
         tag.target: tag for tag in _git.get_tags(repo_root, annotated_only=True)
     }
 
     revisions: list[Revision] = []
-    for commit in commits:
+    for commit in _git.log(repo_root):
         if len(revisions) == limit:
             break
         if commit.timestamp < since:

--- a/gsb/history.py
+++ b/gsb/history.py
@@ -6,7 +6,7 @@ from typing import TypedDict
 from . import _git
 
 
-class Revision(TypedDict):
+class _Revision(TypedDict):
     """Metadata on a GSB-managed version
 
     Parameters
@@ -30,7 +30,7 @@ def get_history(
     include_non_gsb: bool = False,
     limit: int = -1,
     since: dt.date = dt.datetime(1970, 1, 1),
-) -> list[Revision]:
+) -> list[_Revision]:
     """Retrieve a list of GSB-managed versions
 
     Parameters
@@ -65,7 +65,7 @@ def get_history(
         tag.target: tag for tag in _git.get_tags(repo_root, annotated_only=True)
     }
 
-    revisions: list[Revision] = []
+    revisions: list[_Revision] = []
     for commit in _git.log(repo_root):
         if len(revisions) == limit:
             break

--- a/gsb/history.py
+++ b/gsb/history.py
@@ -1,0 +1,59 @@
+"""Functionality for tracking and managing revision history"""
+import datetime as dt
+from pathlib import Path
+from typing import TypedDict
+
+from . import _git
+
+
+class Revision(TypedDict):
+    """Metadata on a GSB-managed version
+
+    Parameters
+    ----------
+    identifier : str
+        A unique identifier for the revision
+    description : str
+        A description of the version
+    timestamp : dt.datetime
+        The time at which the version was created
+    """
+
+    identifier: str
+    description: str
+    timestamp: dt.datetime
+
+
+def get_history(
+    repo_root: Path,
+    tagged_only: bool = True,
+    include_non_gsb: bool = False,
+    limit: int = -1,
+    since: dt.date = dt.datetime(1970, 1, 1),
+) -> list[Revision]:
+    """Retrieve a list of GSB-managed versions
+
+    Parameters
+    ----------
+    repo_root : Path
+        The directory where the repo should be created
+    tagged_only : bool, optional
+        By default, this method only returns tagged backups. To include
+        all available revisions, pass in `tagged_only=False`.
+    include_non_gsb : bool, optional
+        By default, this method excludes any revisions created outside of `gsb`.
+        To include all git commits and tags, pass in `include_non_gsb=True`.
+    limit : int, optional
+        By default, this method returns the entire history. To return only the
+        last _n_ revisions, pass in `limit=n`.
+    since : date or timestamp, optional
+        By default, this method returns the entire history. To return only
+        revisions made on or after a certain date, pass in `since=<start_date>`.
+
+    Returns
+    -------
+    list of dict
+        Metadata on the requested revisions, sorted in reverse-chronological
+        order
+    """
+    raise NotImplementedError

--- a/gsb/test/test_history.py
+++ b/gsb/test/test_history.py
@@ -1,0 +1,173 @@
+"""Tests for reviewing repo histories"""
+import datetime as dt
+
+import pytest
+
+from gsb import _git, history
+
+
+class TestGetHistory:
+    @pytest.fixture
+    def repo_with_history(self, tmp_path):
+        root = tmp_path / "fossil record"
+        root.mkdir()
+        _git.init(root)
+
+        _git.commit(root, "First commit", _committer=("you-ser", "me@computer"))
+        _git.tag(root, "Init", None, _tagger=("you-ser", "me@computer"))
+
+        (root / "species").write_text("trilobite\n")
+        _git.add(root, "species")
+        _git.commit(root, "Add an animal", _committer=("you-ser", "me@computer"))
+
+        with (root / "species").open("a") as f:
+            f.write("hallucigenia\n")
+
+        _git.add(root, "species")
+        _git.commit(root, "I think I'm drunk", _committer=("you-ser", "me@computer"))
+        _git.tag(
+            root,
+            "0.1",
+            "Cambrian period",
+            _tagger=("you-ser", "me@computer"),
+        )
+
+        (root / "species").write_text("trilobite\n")
+        _git.add(root, "species")
+        _git.commit(root, "Remove hallucigenia", _committer=("you-ser", "me@computer"))
+        _git.tag(
+            root,
+            "0.2",
+            "Hello Permian period",
+            _tagger=("you-ser", "me@computer"),
+        )
+
+        (root / "species").unlink()
+        _git.add(root, "species")
+        _git.commit(
+            root, "Oh no! Everyone's dead!", _committer=("you-ser", "me@computer")
+        )
+
+        _git.add(root, "species")
+        _git.commit(root, "Started tracking with gsb")
+        _git.tag(root, "gsb1.0", "Start of gsb tracking")
+
+        (root / "species").write_text(
+            "\n".join(("ichthyosaurs", "archosaurs", "plesiosaurs", "therapsids"))
+            + "\n"
+        )
+
+        _git.add(root, "species")
+        _git.commit(root, "Autocommit")
+        _git.tag(root, "gsb1.1", "Triassic")
+
+        (root / "species").write_text("plesiosaurs\n")
+        _git.add(root, "species")
+        jurassic = _git.commit(root, "Autocommit")
+
+        (root / "species").write_text(
+            "\n".join(("sauropods", "therapods", "plesiosaurs", "pterosaurs", "squids"))
+            + "\n"
+        )
+
+        _git.add(root, "species")
+        _git.commit(root, "Autocommit")
+        _git.tag(root, "gsb1.2", "Jurassic")
+
+        (root / "species").write_text(
+            "\n".join(
+                (
+                    "sauropods",
+                    "therapods",
+                    "raptors",
+                    "pliosaurs",
+                    "plesiosaurs",
+                    "mosasaurs",
+                    "pterosaurs",
+                )
+            )
+            + "\n"
+        )
+
+        _git.add(root, "species")
+        _git.commit(root, "Autocommit")
+
+        with (root / "species").open("a") as f:
+            f.write("mammals\n")
+
+        _git.add(root, "species")
+        _git.commit(root, "It's my ancestors!", _committer=("you-ser", "me@computer"))
+
+        with (root / "species").open("a") as f:
+            f.write("\n".join(("birds", "insects", "shark", "squids")) + "\n")
+
+        _git.add(root, "species")
+        _git.commit(root, "Autocommit")
+
+        _git.tag(root, "gsb1.3", "Cretaceous (my gracious!)")
+
+        yield root, dt.datetime.fromtimestamp(jurassic.commit_time)
+
+    @pytest.fixture
+    def root(self, repo_with_history):
+        yield repo_with_history[0]
+
+    @pytest.fixture
+    def jurassic_timestamp(self, repo_with_history):
+        yield repo_with_history[1]
+
+    def test_get_history_by_default_returns_all_gsb_tags(self, root):
+        assert [revision["identifier"] for revision in history.get_history(root)] == [
+            "gsb1.3",
+            "gsb1.2",
+            "gsb1.1",
+            "gsb1.0",
+        ]
+
+    def test_get_history_can_limit_the_number_of_revisions(self, root):
+        assert [
+            revision["identifier"] for revision in history.get_history(root, limit=1)
+        ] == ["gsb1.3"]
+
+    def test_get_history_can_limit_revisions_by_date(self, root, jurassic_timestamp):
+        assert [
+            revision["identifier"]
+            for revision in history.get_history(root, since=jurassic_timestamp)
+        ] == ["gsb1.3", "gsb1.2"]
+
+    def test_get_history_can_return_interim_commits_as_well(self, root):
+        assert [
+            revision["description"]
+            for revision in history.get_history(root, tagged_only=False)
+        ] == [
+            "Start of gsb tracking",
+            "Triassic",
+            "Autocommit",
+            "Jurassic",
+            "Autocommit",
+            "Cretaceous",
+        ]
+
+    def test_get_history_can_return_non_gsb_tags_as_well(self, root):
+        assert [
+            revision["identifier"]
+            for revision in history.get_history(root, include_non_gsb=True)
+        ] == [
+            "gsb1.3",
+            "gsb1.2",
+            "gsb1.1",
+            "gsb1.0",
+            "0.1",
+            "Init",
+        ]
+
+    def test_get_history_can_return_non_gsb_commits_as_well(self, root):
+        assert [
+            revision["description"]
+            for revision in history.get_history(
+                root, tagged_only=False, include_non_gsb=True, limit=2
+            )
+        ] == [
+            "Cretaceous",
+            "It's my ancestors!",
+        ]

--- a/gsb/test/test_history.py
+++ b/gsb/test/test_history.py
@@ -16,9 +16,9 @@ class TestGetHistory:
         with pytest.raises(OSError):
             history.get_history(random_folder)
 
-    @pytest.fixture
-    def repo_with_history(self, tmp_path):
-        root = tmp_path / "fossil record"
+    @pytest.fixture(scope="class")
+    def repo_with_history(self, tmp_path_factory):
+        root = tmp_path_factory.mktemp("saves") / "fossil record"
         root.mkdir()
         _git.init(root)
 
@@ -70,7 +70,7 @@ class TestGetHistory:
         _git.commit(root, "Autocommit")
         _git.tag(root, "gsb1.1", "Triassic")
 
-        time.sleep(1)  # TODO: this is per-test so it's gonna be really painful
+        time.sleep(1)
 
         (root / "species").write_text("plesiosaurs\n")
         _git.add(root, "species")

--- a/gsb/test/test_init.py
+++ b/gsb/test/test_init.py
@@ -86,7 +86,7 @@ class TestFreshInit:
 
     def test_init_performs_initial_commit(self, root):
         _ = onboard.create_repo(root)
-        history = _git.log(root, -1)
+        history = _git.log(root)
 
         assert [commit.message for commit in history] == ["Started tracking with gsb\n"]
 
@@ -150,7 +150,7 @@ stuff
 
     def test_init_preserves_existing_commits(self, repo_with_history):
         _ = onboard.create_repo(repo_with_history)
-        history = _git.log(repo_with_history, -1)
+        history = _git.log(repo_with_history)
 
         assert [commit.message for commit in history] == [
             "Started tracking with gsb\n",


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Addresses #4, save for the CLI

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Adds the method `history.get_history`, which meets the specs of #4 by:
  * Allowing the user to either fetch all annotated tags or all commits
  * Optionally limiting to only the last `n` revisions
  * Optionally limiting to only revisions on or after a specified timestamp
  * Optionally including commits and (annotated) tags created manually, outside of `gsb`
  * All returned in reverse-chronological order
* Modifies `_git.log` to return a _generator_ that fetches the commits one at a time
* Adds a `.pylintrc` (that I forgot to include in 4cb7fc9b01b97ccb825e1dae8824e6dca47b6bcb)

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->

### Timestamp resolution means tests need to `sleep`
It appears that [_Git itself_](https://stackoverflow.com/questions/28237043/what-is-the-resolution-of-gits-commit-date-or-author-date-timestamps) only resolves timestamps to the second, which means that I'm having to put in a `sleep` to test the operation of the `since` kwarg.

This is mitigated in 9f7242cabfba348d062ef128952bb208a3c28c6f via use of [pytest's `tmp_path_factory` fixture](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmp-path-factory-fixture) to make it so that the git repo needs to be created only once. This is a pattern that should be used sparingly but is safe in this case because `gsb history` does not make any changes.

*Explicitly note that this **does not** affect the ordering of commits--that is guaranteed by the linear history and the fact that we're walking through the commits one at a time*

### author time or commit time?

Looking over the git history, I was surprised it didn't go back farther. Then I remembered that I'd done a bunch of rebasing and realized it was probably using _the date of the rebase_.

In actuality, I just misread the timestamps, but it did clue me into the fact that I have to be _very intentional_ about whether this line:

https://github.com/OpenBagTwo/gsb/blob/d5874a072329e010a91987b62ab5095486465e28/gsb/_git.py#L257

uses `commit.commit_time` (the time of the squash or cherry-pick) vs. `commit.author.time`, which is the time the original commit was made.

What I _want_ is to use the time the _last_ commit was made, but I don't think that's recoverable, so it just needs to be noted in #9 that squashing needs to preserve the _last_ date.

<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- [x] Unit tests :-)
* Tried running this on my own manually-git-managed Minecraft saves folder (which use squashed commits instead of tags), and:
  - [x] `history.show_history(my_saves)` returned empty (because it's not using `gsb` yet)
  - [x] `history.show_history(my_saves, include_non_gsb=True)` returned empty because I've got no tags
  - [x] `history.show_history(my_saves,  include_non_gsb=True, tagged_only=False)` got me metadata on all commits going back to the start of that repo
  - [x] `history.show_history(my_saves,  include_non_gsb=True, tagged_only=False, limit=10)` got me metadata on the last ten commits

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
