### PR TITLE
Implement CLI for gsb rewind

### DIFF
--- a/gsb/history.py
+++ b/gsb/history.py
@@ -83,7 +83,7 @@ def get_history(
         else:
             if tagged_only:
                 continue
-            identifier = commit.hash
+            identifier = commit.hash[:8]
             is_gsb = commit.gsb
             description = commit.message
         if not include_non_gsb and not is_gsb:

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -1,7 +1,11 @@
 """Functionality for restoring to an old backup"""
+import logging
 from pathlib import Path
 
 from . import _git, backup
+from .logging import IMPORTANT
+
+LOGGER = logging.getLogger(__name__)
 
 
 def restore_backup(repo_root: Path, revision: str) -> str:
@@ -32,6 +36,9 @@ def restore_backup(repo_root: Path, revision: str) -> str:
     """
     _git.show(repo_root, revision)
 
+    LOGGER.log(
+        IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
+    )
     orig_head = backup.create_backup(
         repo_root, f"Backing up state before rewinding to {revision}"
     )


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Finishes the implementation of #5 

and actually rounds out [Milestone 2](https://github.com/OpenBagTwo/gsb/milestone/2)!

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* tweaks `history.get_history` to return short commit hashes (doesn't change what the CLI displays
* makes it so that getting the history of a valid repo with no commits returns an empty list rather than raising a pygit2 error
* Implements #5 so that `gsb rewind <hash>` or `gsb rewind <tag>`  rewinds to that point in time and so that `gsb rewind` with no arguments brings up an interactive prompt that lets you choose from a set of recent backups

 
## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- Tested out running `gsb rewind` on the repo containing `gsb`:
  - [x] with no additional argument to check out how the prompt ends up looking
  - [x] with `-v` and `-vv` to check out how the prompt looks with additional information printed
  - [x] Also tested `gsb rewind -q` which just says "select a revision."
  - [x] with invalid commit hashes / tag names to make sure the error I got back looked good 
- The help messages look good for:
  - [x] `gsb --help`
  - [x] `gsb rewind --help` 

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
