### PR TITLE
Allow gsb backup to combine with previous backups

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,6 +50,14 @@ Note that `gsb` has two kinds of backups:
    meant to denote specific points you might want to return to later (right before an epic
    boss fight or right before a story branch).
 
+!!! danger "Pro Tip"
+    You can overwrite a previous backup using the `--combine` / `-c` flag. And if when
+    making a new tagged backup you want to delete all of the untagged backups you've made
+    since the last time you used the `--tag` flag, you can use `-cc`, _e.g._
+    ```bash
+    gsb backup -cc --tag "A backup that's actually important"
+    ```
+
 ## List your backups using `gsb history`
 
 You can view your list of available backups at any time by navigating to your save's folder
@@ -72,8 +80,24 @@ If you want to restore a backup, you can do so via [`gsb rewind`](../cli/#rewind
 If you don't provide a restore point, the command will prompt you to choose from a list
 of recent backups.
 
-## Advanced Hisoty Management directly with Git
+## Deleting a backup with `gsb delete`
+
+Use [`gsb delete`](../cli/#delete) to delete any backups you no longer need. Note
+that this command doesn't _actually_ delete anything on its own (so you won't
+recover any disk space immediately). What it does instead is rewrites your history
+to exclude those restore points, thus marking them as "loose." To permanently
+delete these backups, you will need to download and install a full
+[Git client](https://git-scm.com/downloads) and run a "garbage collect" to prune
+these loose objects.
+
+??? danger "Pruning via the Git CLI"
+    If you have the Git command-line utility installed, the command to run is:
+    ```bash
+    git gc --aggressive --prune=now
+    ```
+
+## Advanced History Management directly with Git
 
 Behind the curtain, `gsb` runs on [Git](https://git-scm.com/) meaning you can run
 any advanced commands you wish on a `gsb`-managed save repo directly via the
-`git` CLI or  any general-purpose Git tool.
+`git` CLI or any general-purpose Git tool.

--- a/gsb/backup.py
+++ b/gsb/backup.py
@@ -81,12 +81,13 @@ def create_backup(
         identifier = _git.commit(
             repo_root, commit_message or tag_message or "GSB-managed commit"
         ).hash
-        logging.info("Changes committed with hash %s", identifier)
+        LOGGER.info("Changes committed with hash %s", identifier[:8])
+        LOGGER.debug("Full hash: %s", identifier)
     except ValueError:
         if not tag_message:
             raise
-        logging.info("Nothing new to commit--all files are up-to-date.")
+        LOGGER.info("Nothing new to commit--all files are up-to-date.")
     if tag_message:
         identifier = _git.tag(repo_root, _generate_tag_name(), tag_message).name
-        logging.log(IMPORTANT, "Created new tagged backup: %s", identifier)
+        LOGGER.log(IMPORTANT, "Created new tagged backup: %s", identifier)
     return identifier

--- a/gsb/backup.py
+++ b/gsb/backup.py
@@ -31,7 +31,10 @@ def _generate_tag_name() -> str:
 
 
 def create_backup(
-    repo_root: Path, tag_message: str | None = None, commit_message: str | None = None
+    repo_root: Path,
+    tag_message: str | None = None,
+    commit_message: str | None = None,
+    parent: str | None = None,
 ) -> str:
     """Create a new backup
 
@@ -48,7 +51,10 @@ def create_backup(
         is provided. Provide a value to this argument to explicitly set the
         commit message. If neither a `tag` nor a `commit_message` is provided,
         the default value will be "GSB-managed commit"
-
+    parent: str, optional
+        By default, this new backup will be created as an incremental commit
+        off of the current head. To instead reset to a specific revision,
+        pass in an ID for that revision to this argument.
 
     Returns
     -------
@@ -61,9 +67,14 @@ def create_backup(
     OSError
         If the specified repo does not exist or is not a gsb-managed repo
     ValueError
-        If there are no changes to commit and no tag message was provided
+        If there are no changes to commit and no tag message was provided, or
+        if the specified "parent" could not be resolved.
     """
     manifest = Manifest.of(repo_root)
+
+    if parent is not None:
+        _git.reset(repo_root, parent, hard=False)
+
     _git.add(repo_root, manifest.patterns)
     _git.force_add(repo_root, REQUIRED_FILES)
     try:

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -106,9 +106,9 @@ def backup(repo_root: Path, path_as_arg: Path | None, tag: str | None, combine: 
         except ValueError as probably_not_enough_values:
             if "not enough values to unpack" in str(probably_not_enough_values):
                 LOGGER.error("Cannot combine with the very first backup.")
-            else:
-                LOGGER.error(probably_not_enough_values)
-            sys.exit(1)
+                sys.exit(1)
+            raise probably_not_enough_values  # pragma: no-cover
+
         LOGGER.log(IMPORTANT, "Combining with %s", combine_me["identifier"])
         if combine_me["tagged"]:
             LOGGER.warning("Are you sure you want to overwrite a tagged backup?")

--- a/gsb/fastforward.py
+++ b/gsb/fastforward.py
@@ -93,7 +93,7 @@ def rewrite_history(repo_root: Path, starting_point: str, *revisions: str) -> st
                             (revision.annotation or revision.name)
                             + "\n\n"
                             + f"rebase of {revision.target.hash}"
-                            + f' ("{revision.target.message}")'
+                            + f' ("{revision.target.message.strip()}")'
                         ),
                         timestamp=revision.target.timestamp,
                     ).hash

--- a/gsb/history.py
+++ b/gsb/history.py
@@ -21,11 +21,17 @@ class _Revision(TypedDict):
         A description of the version
     timestamp : dt.datetime
         The time at which the version was created
+    tagged : bool
+        Whether or not this is a tagged revision
+    gsb : bool
+        Whether or not this is a GSB-created revision
     """
 
     identifier: str
     description: str
     timestamp: dt.datetime
+    tagged: bool
+    gsb: bool
 
 
 def get_history(
@@ -89,12 +95,14 @@ def get_history(
         if tag := tag_lookup.get(commit):
             if since_last_tagged_backup:
                 break
+            tagged = True
             identifier = tag.name
             is_gsb = tag.gsb if tag.gsb is not None else commit.gsb
             description = tag.annotation or commit.message
         else:
             if tagged_only:
                 continue
+            tagged = False
             identifier = commit.hash[:8]
             is_gsb = commit.gsb
             description = commit.message
@@ -122,6 +130,8 @@ def get_history(
                 "identifier": identifier,
                 "description": description.strip(),
                 "timestamp": commit.timestamp,
+                "tagged": tagged,
+                "gsb": is_gsb,
             }
         )
     return revisions

--- a/gsb/history.py
+++ b/gsb/history.py
@@ -10,7 +10,7 @@ from .logging import IMPORTANT
 LOGGER = logging.getLogger(__name__)
 
 
-class _Revision(TypedDict):
+class Revision(TypedDict):
     """Metadata on a GSB-managed version
 
     Parameters
@@ -44,7 +44,7 @@ def get_history(
     limit: int = -1,
     since: dt.date = dt.datetime(1970, 1, 1),
     since_last_tagged_backup: bool = False,
-) -> list[_Revision]:
+) -> list[Revision]:
     """Retrieve a list of GSB-managed versions
 
     Parameters
@@ -84,7 +84,7 @@ def get_history(
     }
     LOGGER.debug("Retrieved %s tags", len(tag_lookup))
 
-    revisions: list[_Revision] = []
+    revisions: list[Revision] = []
     for commit in _git.log(repo_root):
         if len(revisions) == limit:
             break
@@ -119,7 +119,7 @@ def get_history(
     return revisions
 
 
-def log_revision(revision: _Revision, idx: int | None) -> None:
+def log_revision(revision: Revision, idx: int | None) -> None:
     """Print (log) a revision
 
     Parameters
@@ -153,7 +153,7 @@ def show_history(
     repo_root: Path,
     numbering: int | None = 1,
     **kwargs,
-) -> list[_Revision]:
+) -> list[Revision]:
     """Fetch and print (log) the list of versions for the specified repo matching
     the given specs
 
@@ -166,13 +166,13 @@ def show_history(
         results, starting at 1. To set a different starting number, provide that.
         To use "-" instead of numbers, pass in `numbering=None`.
     **kwargs
-        Any other options will be passed directly to the lower-level `get_history()`
+        Any other options will be passed directly to `get_history()`
         method
 
     Notes
     -----
-    See the documentation for `log_revision()` for details about what information
-    is logged to each log level
+    See `log_revision()` for details about what information is logged to each
+    log level
 
     Returns
     -------

--- a/gsb/test/conftest.py
+++ b/gsb/test/conftest.py
@@ -34,7 +34,7 @@ def patch_tag_naming(monkeypatch):
     monkeypatch.setattr(backup, "_generate_tag_name", mock_tag_namer)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def _repo_with_history(tmp_path_factory):
     root = tmp_path_factory.mktemp("saves") / "fossil record"
     root.mkdir()
@@ -129,7 +129,7 @@ def _repo_with_history(tmp_path_factory):
     _git.commit(root, "It's my ancestors!", _committer=("you-ser", "me@computer"))
 
     with (root / "species").open("a") as f:
-        f.write("\n".join(("birds", "insects", "shark", "squids")) + "\n")
+        f.write("\n".join(("birds", "insects", "sharks", "squids")) + "\n")
 
     _git.add(root, ["species"])
     _git.commit(root, "Autocommit")
@@ -148,6 +148,6 @@ def root(_repo_with_history, tmp_path):
     yield destination
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def jurassic_timestamp(_repo_with_history):
     yield _repo_with_history[1]

--- a/gsb/test/test_backup.py
+++ b/gsb/test/test_backup.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import pygit2
 import pytest
 
-from gsb import _git, backup, history, onboard
+from gsb import _git, backup, onboard
+from gsb.history import get_history
 from gsb.manifest import Manifest
 
 
@@ -108,7 +109,7 @@ class TestCreateBackup:
         identifier = backup.create_backup(root, parent="gsb1.2")
         assert [
             revision["identifier"]
-            for revision in history.get_history(
+            for revision in get_history(
                 root, tagged_only=False, include_non_gsb=True, limit=2
             )
         ] == [identifier[:8], "gsb1.2"]
@@ -191,7 +192,7 @@ class TestCLI:
 
         assert [
             revision["identifier"]
-            for revision in history.get_history(
+            for revision in get_history(
                 root, tagged_only=False, include_non_gsb=True, limit=2
             )
         ] == [commit_id, "gsb1.3"]
@@ -225,9 +226,9 @@ class TestCLI:
             assert "Aborting" in result.stderr.decode().splitlines()[-1]
 
             assert (
-                history.get_history(
-                    root, tagged_only=False, include_non_gsb=True, limit=1
-                )[0]["identifier"]
+                get_history(root, tagged_only=False, include_non_gsb=True, limit=1)[0][
+                    "identifier"
+                ]
                 == "gsb1.3"
             )
 
@@ -265,7 +266,7 @@ class TestCLI:
 
         assert [
             revision["identifier"]
-            for revision in history.get_history(
+            for revision in get_history(
                 root, tagged_only=False, include_non_gsb=True, limit=2
             )
         ] == [commit_id, "gsb1.3"]
@@ -285,13 +286,15 @@ class TestCLI:
             + "\n"
         )
 
-        result = subprocess.run(["gsb", "backup", "-cc"], cwd=root, capture_output=True)
+        result = subprocess.run(
+            ["gsb", "backup", "-qcc"], cwd=root, capture_output=True
+        )
 
         assert not result.stderr.decode()
 
         assert (
-            history.get_history(root, tagged_only=False, include_non_gsb=True, limit=2)[
-                -1
-            ]["identifier"]
+            get_history(root, tagged_only=False, include_non_gsb=True, limit=2)[-1][
+                "identifier"
+            ]
             == "gsb1.3"
         )


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Implements #34

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* `gsb backup -c` will combine any new changes with the previous backup
  * and prompt for confirmation if that backup is tagged
* `gsb backup -cc` will combine any new changes with _all_ untagged backups since the last tagged backup (and will behave trivially if there are no new tagged backups)
* Addressing some of the tech debt from #33, `history.get_history` has been refactored to separate the fetching from the logging
* Fixed a bug where "rebased" commits weren't removing the trailing newline from the messages of the original commits
* Adds usage docs for `-c`, `-cc` and also `gsb delete`
* Switches the scope of the `_repo_with_history` fixture from module-level to session-level, which should be perfectly safe

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- I've tested out the prompts and logging messages I get when using the `-c` and `-cc` flags, and they look good to me.
- After this PR is merged I'll be cutting a beta release to allow me to dogfood this new functionality (I see `gsb -cc --tag "message"` becoming my standard operating procedure).

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
