### PR TITLE
Always include most recent revision in gsb history and rewind

### DIFF
--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -226,7 +226,9 @@ def history(
     if since is not None:
         kwargs["since"] = since
 
-    history_.show_history(path_as_arg or repo_root, **kwargs)
+    history_.show_history(
+        path_as_arg or repo_root, **kwargs, always_include_latest=True
+    )
 
 
 @click.option(

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -282,7 +282,7 @@ def _prompt_for_a_recent_revision(repo_root) -> str:
 
     LOGGER.log(
         IMPORTANT,
-        "\nSelect one by number or revision (or [q]uit and"
+        "\nSelect one by number or identifier (or [q]uit and"
         " call gsb history yourself to get more revisions).",
     )
 

--- a/gsb/test/conftest.py
+++ b/gsb/test/conftest.py
@@ -7,7 +7,7 @@ from typing import Generator
 import pytest
 
 from gsb import _git, backup
-from gsb.manifest import Manifest
+from gsb.manifest import MANIFEST_NAME, Manifest
 
 
 @pytest.fixture(autouse=True)
@@ -78,7 +78,7 @@ def _repo_with_history(tmp_path_factory):
 
     Manifest(root, ("species",)).write()
     (root / ".gitignore").touch()
-    _git.add(root, ["species", ".gsb_manifest", ".gitignore"])
+    _git.add(root, ["species", MANIFEST_NAME, ".gitignore"])
     _git.tag(root, "gsb1.0", "Start of gsb tracking")
 
     (root / "species").write_text(
@@ -135,6 +135,31 @@ def _repo_with_history(tmp_path_factory):
     _git.commit(root, "Autocommit")
 
     _git.tag(root, "gsb1.3", "Cretaceous (my gracious!)")
+
+    (root / "continents").write_text(
+        "\n".join(
+            (
+                "laurasia",
+                "gondwana",
+            )
+        )
+        + "\n"
+    )
+    Manifest.of(root)._replace(patterns=("species", "continents", "oceans")).write()
+    _git.add(root, ("continents",))
+    _git.force_add(root, (MANIFEST_NAME,))
+    _git.commit(root, "Autocommit")
+
+    # these contents are new since the last commit
+    (root / "oceans").write_text(
+        "\n".join(
+            (
+                "pacific",
+                "tethys",
+            )
+        )
+        + "\n"
+    )
 
     yield root, jurassic.timestamp
 

--- a/gsb/test/conftest.py
+++ b/gsb/test/conftest.py
@@ -6,7 +6,7 @@ from typing import Generator
 
 import pytest
 
-from gsb import _git, backup
+from gsb import _git, backup, history
 from gsb.manifest import MANIFEST_NAME, Manifest
 
 
@@ -176,3 +176,10 @@ def root(_repo_with_history, tmp_path):
 @pytest.fixture(scope="session")
 def jurassic_timestamp(_repo_with_history):
     yield _repo_with_history[1]
+
+
+@pytest.fixture(scope="session")
+def all_backups(_repo_with_history):
+    yield history.get_history(
+        _repo_with_history[0], tagged_only=False, include_non_gsb=True
+    )

--- a/gsb/test/test_delete.py
+++ b/gsb/test/test_delete.py
@@ -10,11 +10,6 @@ from gsb.history import get_history
 from gsb.rewind import restore_backup
 
 
-@pytest.fixture(scope="module")
-def all_backups(_repo_with_history):
-    yield get_history(_repo_with_history[0], tagged_only=False, include_non_gsb=True)
-
-
 class TestDeleteBackups:
     def test_deleting_a_backup(self, root):
         fastforward.delete_backups(root, "gsb1.1")

--- a/gsb/test/test_delete.py
+++ b/gsb/test/test_delete.py
@@ -299,7 +299,7 @@ class TestCLI:
         )
         log_lines = result.stderr.decode().strip().splitlines()
 
-        assert "No gsb revisions found" in log_lines[1]
+        assert "No GSB revisions found" in log_lines[1]
         assert f"{commit_hash}" in log_lines[2]
 
     def test_running_on_empty_repo_raises(self, tmp_path):

--- a/gsb/test/test_history.py
+++ b/gsb/test/test_history.py
@@ -5,7 +5,6 @@ import pytest
 
 from gsb import history
 from gsb.backup import create_backup
-from gsb.manifest import Manifest
 
 
 class TestGetHistory:
@@ -41,6 +40,7 @@ class TestGetHistory:
             revision["description"]
             for revision in history.get_history(root, tagged_only=False)
         ] == [
+            "Autocommit",
             "Cretaceous (my gracious!)",
             "Autocommit",
             "Jurassic",
@@ -66,36 +66,16 @@ class TestGetHistory:
         assert [
             revision["description"]
             for revision in history.get_history(
-                root, tagged_only=False, include_non_gsb=True, limit=2
+                root, tagged_only=False, include_non_gsb=True, limit=3
             )
         ] == [
+            "Autocommit",
             "Cretaceous (my gracious!)",
             "It's my ancestors!",
         ]
 
     def test_getting_revisions_since_last_tagged_backup(self, root):
-        (root / "continents").write_text(
-            "\n".join(
-                (
-                    "laurasia",
-                    "gondwana",
-                )
-            )
-            + "\n"
-        )
-        Manifest.of(root)._replace(patterns=("species", "continents", "oceans")).write()
         create_backup(root)
-        (root / "oceans").write_text(
-            "\n".join(
-                (
-                    "pacific",
-                    "tethys",
-                )
-            )
-            + "\n"
-        )
-        create_backup(root)
-
         assert (
             len(
                 history.get_history(
@@ -183,11 +163,11 @@ class TestCLI:
 
         backups = [
             line.split(" from ")[0]
-            for line in [result.stderr.decode().splitlines()[i] for i in [0, 2, 4, 5]]
+            for line in [result.stderr.decode().splitlines()[i] for i in [1, 3, 5, 6]]
         ]
         assert backups == [
-            "1. gsb1.3",
-            "3. gsb1.2",
-            "5. gsb1.1",
-            "6. gsb1.0",
+            "2. gsb1.3",
+            "4. gsb1.2",
+            "6. gsb1.1",
+            "7. gsb1.0",
         ]

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -150,7 +150,7 @@ class TestCLI:
         )
 
         assert (
-            "Select one by number or revision"
+            "Select one by number or identifier"
             in result.stderr.decode().strip().splitlines()[-2]
         )
 
@@ -163,7 +163,7 @@ class TestCLI:
         )
 
         assert (
-            "Select one by number or revision"
+            "Select one by number or identifier"
             in result.stderr.decode().strip().splitlines()[-2]
         )
 

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -209,7 +209,7 @@ class TestCLI:
         if is_gsb:
             commit_hash = backup.create_backup(repo)
         else:
-            _git.force_add(repo, (Path("save") / "data.txt",))
+            _git.add(repo, ("save",))
             commit_hash = _git.commit(
                 repo, "Sneakier and Sneakier", _committer=("you-ser", "me@computer")
             ).hash


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Resolves #30 

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* The low-level `history.get_history` method now has the option to force the inclusion of the most recent commit, regardless of whether it's tagged or if it was created by GSB
* `gsb history` uses this flag to always return the most recent "backup" at the top of the list
* The `gsb rewind` prompt will now show the most recent commit as "Option 0."
* Tests have been refactored (and rewritten) so that the session "_repo_with_history` fixture now includes a post-tag commit and a post-commit change
* The CLI messages have been tweaked slightly (with a nod towards #44)

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->

The "zeroth" rewind option may be a duplicate of the first, but I have zero problem with that.

<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
Ran `gsb history` and `gsb rewind` on this project's Git repo with the expected outcome. Also tried them out on a GSB-managed repo.

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
