### PR TITLE
Prevent tag conflicts on gsb rewinds

### DIFF
--- a/gsb/backup.py
+++ b/gsb/backup.py
@@ -12,13 +12,13 @@ REQUIRED_FILES: tuple[Path, ...] = (Path(".gitignore"), Path(MANIFEST_NAME))
 LOGGER = logging.getLogger(__name__)
 
 
-def _generate_tag_name() -> str:
+def generate_tag_name() -> str:
     """Generate a new calver-ish tag name
 
     Returns
     -------
     str
-        A tag name that should hopefully be distinctly gsb and distinct
+        A tag name that should hopefully be distinctly GSB and distinct
         from any tags a user would manually create
 
     Notes
@@ -35,6 +35,7 @@ def create_backup(
     tag_message: str | None = None,
     commit_message: str | None = None,
     parent: str | None = None,
+    tag_name: str | None = None,
 ) -> str:
     """Create a new backup
 
@@ -55,6 +56,10 @@ def create_backup(
         By default, this new backup will be created as an incremental commit
         off of the current head. To instead reset to a specific revision,
         pass in an ID for that revision to this argument.
+    tag_name : str, optional
+        By default, tag names are automatically generated. Use this argument to
+        provide a custom tag name. This option is ignored when not creating
+        a tag.
 
     Returns
     -------
@@ -88,6 +93,8 @@ def create_backup(
             raise
         LOGGER.info("Nothing new to commit--all files are up-to-date.")
     if tag_message:
-        identifier = _git.tag(repo_root, _generate_tag_name(), tag_message).name
+        identifier = _git.tag(
+            repo_root, tag_name or generate_tag_name(), tag_message
+        ).name
         LOGGER.log(IMPORTANT, "Created new tagged backup: %s", identifier)
     return identifier

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -8,6 +8,23 @@ from .logging import IMPORTANT
 LOGGER = logging.getLogger(__name__)
 
 
+def generate_restore_tag_name(revision: str) -> str:
+    """Generate a new calver-ish tag name
+
+    Parameters
+    ----------
+    revision : str
+        The commit hash or tag name of the backup to restore
+
+    Returns
+    -------
+    str
+        A tag name that indicates both the time a backup was restored and the
+        identifier of the original revision
+    """
+    return f"{backup.generate_tag_name()}.restore_of_{revision}"
+
+
 def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) -> str:
     """Rewind to a previous backup state and create a new backup
 
@@ -51,4 +68,8 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
     _git.reset(repo_root, orig_head, hard=False)
     if keep_gsb_files:
         _git.checkout_files(repo_root, orig_head, backup.REQUIRED_FILES)
-    return backup.create_backup(repo_root, f"Restored to {revision}")
+    return backup.create_backup(
+        repo_root,
+        f"Restored to {revision}",
+        tag_name=generate_restore_tag_name(revision),
+    )

--- a/gsb/test/conftest.py
+++ b/gsb/test/conftest.py
@@ -31,7 +31,7 @@ def patch_tag_naming(monkeypatch):
     def mock_tag_namer() -> str:
         return next(tag_namer)
 
-    monkeypatch.setattr(backup, "_generate_tag_name", mock_tag_namer)
+    monkeypatch.setattr(backup, "generate_tag_name", mock_tag_namer)
 
 
 @pytest.fixture(scope="session")

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -1,6 +1,6 @@
 """Tests for restoring backups"""
 import subprocess
-from pathlib import Path
+import time
 
 import pytest
 
@@ -141,6 +141,18 @@ class TestRestoreBackup:
         rewind.restore_backup(repo, first_commit["identifier"])
 
         assert (repo / MANIFEST_NAME).exists()
+
+    def test_rewind_tag_naming_doesnt_cause_conflicts(self, tmp_path):
+        repo_root = tmp_path / "repossess"
+        repo_root.mkdir()
+        onboard.create_repo(repo_root, "furniture")
+        restore_point = get_history(repo_root, limit=1)[0]
+        (repo_root / "furniture").mkdir()
+        (repo_root / "furniture" / "sofa").write_text("I'm the king!")
+        backup.create_backup(repo_root)
+        time.sleep(1)  # blergh
+        rewind.restore_backup(repo_root, restore_point["identifier"])
+        assert not (repo_root / "furniture" / "sofa").exists()
 
 
 class TestCLI:

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -63,6 +63,13 @@ class TestRestoreBackup:
         rewind.restore_backup(repo, "gsb2023.07.13")
         assert (repo / "save" / "data.txt").read_text() == "6\n"
 
+    def test_restore_tag_references_the_restored_version(self, repo):
+        rewind.restore_backup(repo, "gsb2023.07.10")
+        assert (
+            get_history(repo, limit=1)[0]["identifier"]
+            == "gsb2023.07.16.restore_of_gsb2023.07.10"
+        )
+
     def test_restores_file_content_to_a_previous_commit(self, repo):
         commit_two = list(get_history(repo, tagged_only=False))[-4]
         assert not commit_two["identifier"].startswith("gsb")  # not a tag


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Fixes #42

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* `gsb rewind` now produces tags of the (extremely verbose) form: https://github.com/OpenBagTwo/gsb/blob/f5bedf4f2d1d7cb625b6e7415802ba8cee40543f/gsb/rewind.py#L25

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
I successfully created a test that reproduced the error described in #42 (and even found out through debugging that the long "commit hash" was actually a _tag_ hash that I couldn't do much about). The implementation fixes that failing test. 

To more strongly validate this, I'm planning on cutting a beta release upon merging this PR that I can easily install for testing on my systems that use GSB.

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
