### PR TITLE
Implement exporting of backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ through the
 
 This project--the executable, source code and all documentation--are published
 under the
-[GNU Public License v3](https://github.com/OpenBagTwo/gsb/blob/dev/LICENSE),
+[GNU Public License v3](https://github.com/OpenBagTwo/gsb/blob/dev/LICENSE) unless otherwise stated,
 and any contributions to or derivatives of this project _must_ be licensed under
 compatible terms.

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - python=3.11
 - pygit2=1.12
 - click=8.0
+- pathvalidate>=2.5
 - ipython>=8
 - jupyterlab>=3
 - black

--- a/gsb/_git.py
+++ b/gsb/_git.py
@@ -767,7 +767,7 @@ def delete_branch(repo_root: Path, branch_name: str) -> None:
 
 def archive(repo_root: Path, filename: Path, reference: str = "HEAD") -> None:
     """Create a standalone archive containing the files in the repo at the
-    current HEAD
+    current HEAD, equivalent to running `git archive -o <filename>`
 
     Parameters
     ----------
@@ -800,14 +800,14 @@ def archive(repo_root: Path, filename: Path, reference: str = "HEAD") -> None:
 
     match tuple(suffix.lower() for suffix in filename.suffixes):
         case ():
-            raise ValueError(f"{filename} does not specify an extension.")
+            raise ValueError(f"Filename {filename} does not specify an extension.")
         case *_, ".tar":
             opener = partial(tarfile.open, mode="x:")
         case (*_, ".tgz") | (*_, ".tar", ".gz"):
             opener = partial(tarfile.open, mode="x:gz")
         case (*_, ".tbz2" | ".tbz") | (*_, ".tar", (".bz2" | ".bz")):
             opener = partial(tarfile.open, mode="x:bz2")
-        case (*_, ".txz" | ".tlzma", ".tlz") | (*_, ".tar", (".xz" | ".lzma" | ".lz")):
+        case (*_, ".txz" | ".tlzma" | ".tlz") | (*_, ".tar", (".xz" | ".lzma" | ".lz")):
             opener = partial(tarfile.open, mode="x:xz")
         case (*_, ".zip"):
             with zipfile.ZipFile(

--- a/gsb/_git.py
+++ b/gsb/_git.py
@@ -799,7 +799,7 @@ def archive(repo_root: Path, filename: Path, reference: str = "HEAD") -> None:
     LOGGER.debug("git archive -o %s %s", filename, reference)
 
     match tuple(suffix.lower() for suffix in filename.suffixes):
-        case ("",):
+        case ():
             raise ValueError(f"{filename} does not specify an extension.")
         case *_, ".tar":
             opener = partial(tarfile.open, mode="x:")

--- a/gsb/_git.py
+++ b/gsb/_git.py
@@ -731,7 +731,7 @@ def checkout_branch(repo_root: Path, branch_name: str, target: str | None) -> No
         LOGGER.debug("git checkout %s", branch_name)
         repo.checkout(repo.branches.local[branch_name])
     except KeyError as no_such_branch:
-        raise ValueError(no_such_branch)
+        raise ValueError(no_such_branch) from no_such_branch
 
 
 def delete_branch(repo_root: Path, branch_name: str) -> None:
@@ -757,4 +757,4 @@ def delete_branch(repo_root: Path, branch_name: str) -> None:
         LOGGER.debug("git branch -D %s", branch_name)
         repo.branches.local.delete(branch_name)
     except KeyError as no_such_branch:
-        raise ValueError(no_such_branch)
+        raise ValueError(no_such_branch) from no_such_branch

--- a/gsb/_make_zip_archive.py
+++ b/gsb/_make_zip_archive.py
@@ -1,0 +1,99 @@
+"""ZIP-compatible `repo.write_archive`, stand-alone for easier upstream sharing.
+As it is adapted directly from pygit2, this module is licensed under the
+GNU Public License v2."""
+import datetime as dt
+import zipfile
+from time import time
+
+from pygit2 import GIT_FILEMODE_LINK, Commit, Index, Oid, Repository, Tree
+
+
+def write_zip_archive(
+    repo: Repository,
+    treeish,
+    archive: zipfile.ZipFile,
+    timestamp: int | None = None,
+    prefix: str = "",
+) -> None:
+    """Implementation of `repo.write_archive` that supports ZIP. Writes treeish
+    into an archive.
+
+    If no timestamp is provided and 'treeish' is a commit, its committer
+    timestamp will be used. Otherwise the current time will be used.
+
+    All path names in the archive are added to 'prefix', which defaults to
+    an empty string.
+
+    Parameters
+    ----------
+    repo: Repository
+        The git repository
+    treeish
+        The treeish to write
+    archive : zipfile.ZipFile
+        An archive from the 'zipfile' module.
+    timestamp : int, optional
+        (Epoch) timestamp to use for the files in the archive.
+    prefix : str, optional
+        Extra prefix to add to the path names in the archive.
+
+    Notes
+    -----
+    h/t to https://stackoverflow.com/a/18432983 for the example on converting
+    between `TarInfo` and `ZipInfo`.
+
+    Example
+    -------
+    >>> import tarfile, pygit2
+    >>> from gsb import _git
+    >>> repo = pygit2.Repository('.')
+    >>> with zipfile.ZipFile('foo.zip', 'w') as archive:
+    >>>     _git.write_zip_archive(repo, repo.head.target, archive)
+    """
+    # Try to get a tree form whatever we got
+    # Try to get a tree form whatever we got
+    if isinstance(treeish, (str, Oid)):
+        treeish = repo[treeish]
+
+    tree = treeish.peel(Tree)
+
+    # if we don't have a timestamp, try to get it from a commit
+    if not timestamp:
+        try:
+            commit = treeish.peel(Commit)
+            timestamp = commit.committer.time
+        except Exception:
+            pass
+
+    # as a last resort, use the current timestamp
+    if not timestamp:
+        timestamp = int(time())
+
+    datetime = dt.datetime.fromtimestamp(timestamp)
+    zip_datetime = (
+        # per https://docs.python.org/3/library/zipfile.html#zipfile.ZipInfo.date_time
+        datetime.year,
+        datetime.month,
+        datetime.day,
+        datetime.hour,
+        datetime.minute,
+        datetime.second,
+    )
+
+    index = Index()
+    index.read_tree(tree)
+
+    for entry in index:
+        content = repo[entry.id].read_raw()
+        info = zipfile.ZipInfo(prefix + entry.path)
+        info.file_size = len(content)
+        info.date_time = zip_datetime
+        # info.uname = info.gname = "root"  # git's archive-zip.c does not
+        if entry.mode == GIT_FILEMODE_LINK:
+            raise NotImplementedError(
+                "ZIP archives with symlinks are not currently supported."
+                "\nSee: https://bugs.python.org/issue37921"
+            )
+        # per https://github.com/git/git/blob/3a06386e/archive-zip.c#L339
+        info.external_attr = entry.mode << 16 if (entry.mode & 111) else 0
+        archive.writestr(info, content)

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -400,6 +400,7 @@ def _prompt_for_revisions_to_delete(repo_root: Path) -> tuple[str, ...]:
         "Format for the archived backup. If not specified,"
         " an appropriate one will be chosen based on your OS."
     ),
+    metavar="FORMAT",
 )
 @click.option(
     "--output",

--- a/gsb/export.py
+++ b/gsb/export.py
@@ -1,0 +1,73 @@
+"""Functionality for creating standalone backups"""
+import os
+from pathlib import Path
+
+import pathvalidate
+
+from . import _git
+from .manifest import Manifest
+
+
+def generate_archive_name(repo_name: str, revision: str) -> str:
+    """Programmatically generate a name for an archived backup
+
+    Parameters
+    ----------
+    repo_name : str
+        The alias assigned to the GSB-managed repo
+    revision : str
+        The commit hash or tag name of the backup that's being archived
+
+    Returns
+    -------
+    str
+        A (hopefully) descriptive archive filename, including an OS-appropriate
+        default extension
+
+    Notes
+    -----
+    The default choice of extension (and thus format) is:
+    - zip for Windows
+    - tar.gz for POSIX systems (Mac and Linux)
+    """
+    return pathvalidate.sanitize_filename(
+        f'{repo_name}_{revision}.{"zip" if os.name == "nt" else "tar.gz"}'
+    )
+
+
+def export_backup(
+    repo_root: Path,
+    revision: str,
+    archive_path: Path | None = None,
+) -> None:
+    """Export a backup to a stand-alone archive
+
+    Parameters
+    ----------
+    repo_root : Path
+        The directory containing the GSB-managed repo
+    revision : str
+        The commit hash or tag name of the backup to archive
+    archive_path : Path, optional
+        The full path to save the archive, including the filename and the
+        extension. If None is provided, one will be automatically generated
+        in the current working directory based on the repo's name and the
+        specified revision.
+
+    Raises
+    ------
+    OSError
+        If the specified repo does not exist or is not a GSB-managed repo
+    ValueError
+        If the specified revision does not exist or if the given `archive_path`
+        does not have a valid extension
+    NotImplementedError
+        If the compression schema implied by the `archive_path`'s extension is not
+        supported
+    """
+    if archive_path is None:
+        archive_path = Path(
+            generate_archive_name(Manifest.of(repo_root).name, revision)
+        )
+
+    _git.archive(repo_root, archive_path, revision)

--- a/gsb/export.py
+++ b/gsb/export.py
@@ -33,8 +33,9 @@ def generate_archive_name(
     Notes
     -----
     The default choice of extension (and thus format) is:
+
     - zip for Windows
-    - tar.gz for POSIX systems (Mac and Linux)
+    - tar.gz for all other systems
     """
     if extension is None:
         extension = "zip" if os.name == "nt" else "tar.gz"

--- a/gsb/export.py
+++ b/gsb/export.py
@@ -8,7 +8,9 @@ from . import _git
 from .manifest import Manifest
 
 
-def generate_archive_name(repo_name: str, revision: str) -> str:
+def generate_archive_name(
+    repo_name: str, revision: str, extension: str | None = None
+) -> str:
     """Programmatically generate a name for an archived backup
 
     Parameters
@@ -17,12 +19,16 @@ def generate_archive_name(repo_name: str, revision: str) -> str:
         The alias assigned to the GSB-managed repo
     revision : str
         The commit hash or tag name of the backup that's being archived
+    extension : str, optional
+        The file extension for the archive (thus specifying the archive's format).
+        If None is provided, an appropriate one will be chosen based on the
+        operating system.
 
     Returns
     -------
     str
-        A (hopefully) descriptive archive filename, including an OS-appropriate
-        default extension
+        A (hopefully) descriptive archive filename, including a format-specifying
+        extension
 
     Notes
     -----
@@ -30,9 +36,9 @@ def generate_archive_name(repo_name: str, revision: str) -> str:
     - zip for Windows
     - tar.gz for POSIX systems (Mac and Linux)
     """
-    return pathvalidate.sanitize_filename(
-        f'{repo_name}_{revision}.{"zip" if os.name == "nt" else "tar.gz"}'
-    )
+    if extension is None:
+        extension = "zip" if os.name == "nt" else "tar.gz"
+    return pathvalidate.sanitize_filename(f"{repo_name}_{revision}.{extension}")
 
 
 def export_backup(

--- a/gsb/fastforward.py
+++ b/gsb/fastforward.py
@@ -166,7 +166,7 @@ def delete_backups(repo_root: Path, *revisions: str) -> str:
 
     to_keep: list[str] = []
     for commit in _git.log(repo_root):
-        if commit in to_delete.keys():
+        if commit in to_delete:
             del to_delete[commit]
         else:
             to_keep.insert(0, commit.hash)
@@ -177,10 +177,9 @@ def delete_backups(repo_root: Path, *revisions: str) -> str:
             raise NotImplementedError(
                 "Deleting the initial backup is not currently supported."
             )
-        else:
-            raise ValueError(
-                "The following revisions exist, but they are not within"
-                " the linear commit history:\n"
-                + "\n".join((f"  - {revision}" for revision in to_delete.values()))
-            )
+        raise ValueError(
+            "The following revisions exist, but they are not within"
+            " the linear commit history:\n"
+            + "\n".join((f"  - {revision}" for revision in to_delete.values()))
+        )
     return rewrite_history(repo_root, *to_keep)

--- a/gsb/manifest.py
+++ b/gsb/manifest.py
@@ -22,11 +22,14 @@ class Manifest(NamedTuple):
     ----------
     root : Path
         The directory containing the save / repo
+    name : str
+        The name / alias of the repo
     patterns : tuple of str
         The glob match-patterns that determine which files get tracked
     """
 
     root: Path
+    name: str
     patterns: tuple[str, ...]
 
     @classmethod
@@ -58,6 +61,8 @@ class Manifest(NamedTuple):
                 if isinstance(value, list):
                     value = tuple(value)
                 as_dict[key] = value
+        if "name" not in as_dict:
+            as_dict["name"] = repo_root.resolve().name
         return cls(**as_dict)
 
     def write(self) -> None:

--- a/gsb/onboard.py
+++ b/gsb/onboard.py
@@ -9,7 +9,10 @@ DEFAULT_IGNORE_LIST: tuple[str, ...] = ()
 
 
 def create_repo(
-    repo_root: Path, *patterns: str, ignore: Iterable[str] | None = None
+    repo_root: Path,
+    *patterns: str,
+    ignore: Iterable[str] | None = None,
+    name: str | None = None,
 ) -> Manifest:
     """Create a new `gsb`-managed git repo in the specified location
 
@@ -24,6 +27,9 @@ def create_repo(
     ignore : list of str, optional
         List of glob-patterns to *ignore*. If None are specified, then nothing
         will be ignored.
+    name : str, optional
+        An alias to assign to the repo. If None is provided, the `repo_root`
+        folder's name will be used.
 
     Returns
     -------
@@ -49,7 +55,7 @@ def create_repo(
     _update_gitignore(repo_root, ignore or ())
 
     # enforce round-trip
-    Manifest(repo_root, tuple(patterns)).write()
+    Manifest(repo_root, name or repo_root.resolve().name, tuple(patterns)).write()
     manifest = Manifest.of(repo_root)
 
     backup.create_backup(repo_root, "Start of gsb tracking")

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -51,7 +51,7 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
     Raises
     ------
     OSError
-        If the specified repo does not exist or is not a gsb-managed repo
+        If the specified repo does not exist or is not a GSB-managed repo
     ValueError
         If the specified revision does not exist
     """

--- a/gsb/test/conftest.py
+++ b/gsb/test/conftest.py
@@ -79,6 +79,7 @@ def _repo_with_history(tmp_path_factory):
     Manifest(root, "history of life", ("species",)).write()
     (root / ".gitignore").touch()
     _git.add(root, ["species", MANIFEST_NAME, ".gitignore"])
+    _git.commit(root, "Start of GSB tracking")
     _git.tag(root, "gsb1.0", "Start of gsb tracking")
 
     (root / "species").write_text(

--- a/gsb/test/conftest.py
+++ b/gsb/test/conftest.py
@@ -76,7 +76,7 @@ def _repo_with_history(tmp_path_factory):
     _git.add(root, ["species"])
     _git.commit(root, "Oh no! Everyone's dead!", _committer=("you-ser", "me@computer"))
 
-    Manifest(root, ("species",)).write()
+    Manifest(root, "history of life", ("species",)).write()
     (root / ".gitignore").touch()
     _git.add(root, ["species", MANIFEST_NAME, ".gitignore"])
     _git.tag(root, "gsb1.0", "Start of gsb tracking")

--- a/gsb/test/test_backup.py
+++ b/gsb/test/test_backup.py
@@ -250,7 +250,7 @@ class TestCLI:
         repo.mkdir()
         _git.init(repo)
         (repo / ".gitignore").touch()
-        Manifest(repo, ("something",)).write()
+        Manifest(repo, "blergh", ("something",)).write()
         backup.create_backup(repo)
         (repo / "something").write_text("it's not nothing\n")
         backup.create_backup(repo)

--- a/gsb/test/test_export.py
+++ b/gsb/test/test_export.py
@@ -1,0 +1,88 @@
+"""Tests for exporting standalone backups"""
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from gsb import _git, export
+from gsb.manifest import Manifest
+
+
+class TestExportBackup:
+    @pytest.fixture(autouse=True)
+    def put_autogenned_files_in_tmp(self, root, monkeypatch) -> None:
+        original_archive_method = _git.archive
+
+        def patched_archive(
+            repo_root: Path, filename: Path, reference: str = "HEAD"
+        ) -> None:
+            if not filename.is_absolute():
+                filename = root.parent / filename
+            return original_archive_method(repo_root, filename, reference)
+
+        monkeypatch.setattr(_git, "archive", patched_archive)
+
+    def test_exporting_a_backup(self, root):
+        export.export_backup(root, "gsb1.2")
+        assert len(list(root.parent.glob("history of life_gsb1.2.*"))) == 1
+
+    def test_exporting_a_backup_with_a_specific_filename(self, root, tmp_path):
+        export.export_backup(root, "0.2", tmp_path / "exported.tbz")
+        assert (tmp_path / "exported.tbz").exists()
+
+    @pytest.mark.parametrize(
+        "path_provided", (False, True), ids=("autogenned", "provided")
+    )
+    def test_exporting_will_not_overwrite_existing_file(
+        self, root, tmp_path, path_provided
+    ):
+        (root.parent / "history of life_gsb1.0.zip").touch()
+        (root.parent / "history of life_gsb1.0.tar.gz").touch()
+        (tmp_path / "exported.tar.xz").touch()
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            export.export_backup(
+                root, "gsb1.0", tmp_path / "exported.tar.xz" if path_provided else None
+            )
+
+    def test_writing_zip_archive(self, root, tmp_path):
+        export.export_backup(root, "gsb1.1", tmp_path / "exported.zip")
+        with zipfile.ZipFile(tmp_path / "exported.zip") as archive:
+            assert archive.read("species").decode("utf-8").startswith("ichthyosaurs\n")
+
+    @pytest.mark.parametrize("compression", (None, "gz", "bz2", "xz"))
+    def test_writing_tar_archive(self, root, tmp_path, compression, all_backups):
+        archive_path = tmp_path / "exported.tar"
+        if compression:
+            archive_path = archive_path.with_suffix(f".tar.{compression}")
+
+        export.export_backup(root, all_backups[0]["commit_hash"], archive_path)
+        with tarfile.open(archive_path, f'r:{compression or ""}') as archive:
+            assert archive.extractfile("continents").read().decode(
+                "utf-8"
+            ).strip().splitlines() == [
+                "laurasia",
+                "gondwana",
+            ]
+
+    def test_no_extension_raises_value_error(self, root, tmp_path):
+        with pytest.raises(ValueError, match="does not specify an extension"):
+            export.export_backup(root, "gsb1.2", tmp_path / "archive")
+
+    def test_unknown_extension_raises_not_implemented_error(self, root, tmp_path):
+        with pytest.raises(NotImplementedError):
+            export.export_backup(
+                root, "gsb1.2", tmp_path / "archive.tar.proprietaryext"
+            )
+
+    def test_repo_name_is_sanitized(self, tmp_path, root):
+        repo = tmp_path / "diabolical"
+        repo.mkdir()
+        Manifest(repo, "I\\'m / soo ?evil?", ("doot",)).write()
+        (repo / "doot").touch()
+        _git.init(repo)
+        _git.add(repo, (".gsb_manifest", "doot"))
+        commit = _git.commit(repo, "Blahblah")
+        export.export_backup(repo, commit.hash[:8])
+        assert len(list(root.parent.glob(f"*evil*{commit.hash[:8]}.*"))) == 1

--- a/gsb/test/test_export.py
+++ b/gsb/test/test_export.py
@@ -1,4 +1,5 @@
 """Tests for exporting standalone backups"""
+import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
@@ -86,3 +87,196 @@ class TestExportBackup:
         commit = _git.commit(repo, "Blahblah")
         export.export_backup(repo, commit.hash[:8])
         assert len(list(root.parent.glob(f"*evil*{commit.hash[:8]}.*"))) == 1
+
+
+class TestCLI:
+    def test_no_args_initiates_prompt_in_cwd(self, root):
+        result = subprocess.run(
+            ["gsb", "export"], cwd=root, capture_output=True, input="q\n".encode()
+        )
+
+        assert (
+            "Select one by number or identifier"
+            in result.stderr.decode().strip().splitlines()[-2]
+        )
+
+    def test_passing_in_a_custom_root(self, root):
+        result = subprocess.run(
+            ["gsb", "export", "--path", root.name],
+            cwd=root.parent,
+            capture_output=True,
+            input="q\n".encode(),
+        )
+
+        assert (
+            "Select one by number or identifier"
+            in result.stderr.decode().strip().splitlines()[-2]
+        )
+
+    @pytest.mark.parametrize("how", ("arg", "prompt", "index"))
+    def test_exporting_a_tag_by(self, root, how) -> None:
+        args = ["gsb1.1"] if how == "arg" else []
+        if how == "prompt":
+            script: bytes | None = "gsb1.1\n".encode()
+        elif how == "index":
+            script = "3\n".encode()
+        else:  # how == "arg"
+            script = None
+
+        _ = subprocess.run(
+            ["gsb", "export", *args], cwd=root, capture_output=True, input=script
+        )
+
+        assert len(list(root.glob("history of life_gsb1.1.*"))) == 1
+
+    @pytest.mark.parametrize("how", ("short", "full", "prompt"))
+    def test_exporting_a_commit_by_(self, root, all_backups, how):
+        assert not all_backups[0]["tagged"]
+        some_commit = all_backups[0]["commit_hash"]
+
+        if how != "full":
+            some_commit = some_commit[:8]
+
+        args = [some_commit] if how != "prompt" else []
+        script = None if how != "prompt" else "0\n".encode()
+
+        _ = subprocess.run(
+            ["gsb", "export", *args],
+            cwd=root,
+            capture_output=True,
+            input=script,
+        )
+
+        assert len(list(root.glob(f"history of life_{some_commit}.*"))) == 1
+
+    @pytest.mark.parametrize("how", ("by_argument", "by_prompt"))
+    def test_unknown_revision_raises_error(self, root, how):
+        args = ["gsb", "export"]
+        answers = [""]
+        if how == "by_argument":
+            args.append("not_a_thing")
+        else:
+            answers.insert(0, "not_a_thing")
+
+        result = subprocess.run(
+            args,
+            cwd=root,
+            capture_output=True,
+            input="\n".join(answers).encode(),
+        )
+
+        assert result.returncode == 1
+        assert "Could not find" in result.stderr.decode().strip().splitlines()[-1]
+
+    def test_running_on_repo_with_no_tags_retrieves_gsb_commits(self, tmp_path):
+        """Like, I guess if the user deleted the initial backup"""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        something = repo / "file"
+        something.touch()
+        _git.init(repo)
+        _git.add(repo, [something.name])
+        commit_hash = _git.commit(repo, "Hello").hash[:8]
+
+        result = subprocess.run(
+            ["gsb", "export"], cwd=repo, capture_output=True, input="q\n".encode()
+        )
+        assert f"1. {commit_hash}" in result.stderr.decode().strip().splitlines()[1]
+
+    def test_specifying_archive_name(self, root):
+        subprocess.run(
+            ["gsb", "export", "gsb1.0", "-o", "../archive.tar"],
+            cwd=root,
+            capture_output=True,
+        )
+
+        with tarfile.open(root.parent / "archive.tar", "r") as archive:
+            assert (
+                archive.extractfile(".gitignore").read().decode("utf-8").strip() == ""
+            )
+
+    def test_raises_if_archive_name_has_no_extension(self, root):
+        result = subprocess.run(
+            ["gsb", "export", "gsb1.0", "-o", "../archive"],
+            cwd=root,
+            capture_output=True,
+        )
+
+        assert result.returncode == 1
+        assert "extension" in result.stderr.decode().splitlines()[-1]
+
+    @pytest.mark.parametrize("filename", ("provided_filename", "autogen_filename"))
+    @pytest.mark.parametrize("how", ("explicit", "short_flag"))
+    @pytest.mark.parametrize(
+        "archive_format", ("zip", "tar", "tar.gz", "tar.bz2", "tar.xz")
+    )
+    def test_specifying_an_archive_format(self, root, archive_format, how, filename):
+        if how == "explicit":
+            args = [f"--format=.{archive_format}"]
+        else:
+            args = [
+                {
+                    "zip": "-p",
+                    "tar": "-t",
+                    "tar.gz": "-z",
+                    "tar.bz2": "-j",
+                    "tar.xz": "-J",
+                }[archive_format]
+            ]
+
+        if filename == "provided_filename":
+            expected_path = root.parent / f"archive.{archive_format}"
+            args.extend(["--output", "../archive"])
+        else:
+            expected_path = root / f"history of life_gsb1.3.{archive_format}"
+
+        subprocess.run(
+            ["gsb", "export", "gsb1.3", *args], cwd=root, capture_output=True
+        )
+
+        if archive_format == "zip":
+            with zipfile.ZipFile(expected_path) as archive:
+                assert (
+                    archive.read("species")
+                    .decode("utf-8")
+                    .strip()
+                    .splitlines()[-1]
+                    .strip()
+                    == "squids"
+                )
+        else:
+            with tarfile.open(expected_path) as archive:
+                assert (
+                    archive.extractfile("species")
+                    .read()
+                    .decode("utf-8")
+                    .strip()
+                    .splitlines()[-1]
+                    .strip()
+                    == "squids"
+                )
+
+    @pytest.mark.parametrize(
+        "flags",
+        (
+            ["-jJ"],
+            ["-z", "-t"],
+            ["-p", "--format", "zip"],
+            pytest.param(
+                ["-zz"],
+                marks=pytest.mark.xfail(
+                    reason="this would be nasty to implement in Click"
+                ),
+            ),
+        ),
+        ids=("short_combined", "short_separate", "short_and_long", "repeated_flag"),
+    )
+    def test_raises_if_multiple_formats_are_specified(self, root, flags):
+        result = subprocess.run(
+            ["gsb", "export", *flags, "0.2"],
+            cwd=root,
+            capture_output=True,
+        )
+
+        assert result.returncode == 1
+        assert "conflicting" in result.stderr.decode().splitlines()[-1].lower()

--- a/gsb/test/test_init.py
+++ b/gsb/test/test_init.py
@@ -193,6 +193,19 @@ stuff
         assert {tag.annotation for tag in tags} == expected
 
 
+class TestBackwardsCompatibility:
+    def test_manifests_without_name_inherit_name_from_folder(self, tmp_path):
+        (tmp_path / MANIFEST_NAME).write_text(
+            """
+generated_by_gsb = "0.0.2-rc2"
+last_modified = "2023-08-05"
+patterns = [
+]
+"""
+        )
+        assert Manifest.of(tmp_path).name == tmp_path.name
+
+
 class TestCLI:
     @pytest.fixture
     def root(self, tmp_path):

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     license="GPL v3",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    install_requires=["pygit2>=1.12", "click>=8"],
+    install_requires=["pygit2>=1.12", "click>=8", "pathvalidate>=2.5"],
     extras_require={"test": ["pytest>=7", "pytest-cov>=4"]},
 )


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Resolves #10 via a new verb: `gsb export` which supports creating an archive of any revision in the Git history in either zip or tar (including compressed tar) format. 

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Adds [a standalone `git archive` implementation](https://github.com/OpenBagTwo/gsb/blob/073e3ac3ee63fc20248dbd3a5b905fe3bf5ee18e/gsb/export.py) to the codebase that supports Zip files (see: https://github.com/libgit2/pygit2/issues/1239)
  * This module is licensed under GPLv2, as it borrows heavily from code existing in the GPLv2-licensed pygit2 library
* This allows `export.export_backup` to support for creating tar and zip archives, applying the appropriate format and compression based on the specified filename (which, in lieu of user-specification, is programmatically generated)
* Exposes a `gsb export` CLI that has support for specifying the archive format implicitly via filename or explicitly using a series of mutually-exclusive flags (which is a pain in the toucans to do with Click (see: https://github.com/pallets/click/issues/257)
  * I did look into using [click-option-group](https://click-option-group.readthedocs.io/en/latest/) but I must have been doing something wrong, because neither the documentation nor the actual mutual-exclusion checking were working as intended.

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->

`gsb export` can be slow (for example, exporting a 3GB backup to a `tar.xz`). I don't believe `tarfile` supports multithreading, and I don't even know for certain that it doesn't require holding the entire tarball in memory during compression. _Probably_ the best practice for power-users will be to export as uncompressed tar and then use `xz` standalone to perform the compression. This is something I may play with.

Export does not support ZIP archives that contain symlinks. That's a limitation of the `zipfile` library (see: https://bugs.python.org/issue37921). Given that ZIP is the default format for Windows users, I'm hoping that symlinks-in-backups is relatively rare / something that's easily mitigated by using a format flag.

<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- Used the CLI to create backups of this project's Git repo at various tags and commits
  - generally this will error out for non-GSB repos, but if you provide the filename, it won't actually check for a manifest)
- Used the CLI to create an auto-named archive of an actual GSB-managed repo
- Confirmed that zip and tar archives show the same timestamps for their file contents (meaning I did https://github.com/OpenBagTwo/gsb/blob/f553fd82c02219d6404116e99f7aa61fcd0bdd4e/gsb/_make_zip_archive.py#L73-L81 correctly)
- [x] need to triple-check that Finder uncompresses `.tar.gz` files out-of-the-box with a single click. If that's not the case, I'll have to switch their default to either `.tgz` or `.zip`.

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- ~~[ ] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)~~
  
  Technically GPLv2 is incompatible with GPLv3, which is part of the reason I've kept the module fully separate.
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
