### PR TITLE
Prevent gsb backup from overwriting existing tags

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,4 +43,4 @@ jobs:
       run: |
         mkdir -p sandbox
         cd sandbox
-        gsb test gsb -vv --doctest-modules --ignore-glob="docs/**" --log-level=DEBUG
+        gsb test -vv --ignore-glob="docs/**" --log-level=DEBUG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,4 +43,4 @@ jobs:
       run: |
         mkdir -p sandbox
         cd sandbox
-        gsb test --doctest-modules --ignore-glob="docs/**" --log-level=DEBUG
+        gsb test gsb -vv --doctest-modules --ignore-glob="docs/**" --log-level=DEBUG

--- a/gsb/_make_zip_archive.py
+++ b/gsb/_make_zip_archive.py
@@ -48,7 +48,7 @@ def write_zip_archive(
     >>> from gsb import _git
     >>> repo = pygit2.Repository('.')
     >>> with zipfile.ZipFile('foo.zip', 'w') as archive:
-    >>>     _git.write_zip_archive(repo, repo.head.target, archive)
+    ...     _git.write_zip_archive(repo, repo.head.target, archive)
     """
     # Try to get a tree form whatever we got
     # Try to get a tree form whatever we got

--- a/gsb/backup.py
+++ b/gsb/backup.py
@@ -93,6 +93,10 @@ def create_backup(
             raise
         LOGGER.info("Nothing new to commit--all files are up-to-date.")
     if tag_message:
+        head = _git.show(repo_root, "HEAD")
+        for tag in _git.get_tags(repo_root, annotated_only=True):
+            if tag.target == head:
+                raise ValueError(f"The current HEAD is already tagged as {tag.name}")
         identifier = _git.tag(
             repo_root, tag_name or generate_tag_name(), tag_message
         ).name

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -361,35 +361,35 @@ def _prompt_for_revisions_to_delete(repo_root: Path) -> tuple[str, ...]:
     "xz_flag",
     is_flag=True,
     flag_value="tar.xz",
-    help="Export as a .tar.xz archive",
+    help="Export as a .tar.xz archive.",
 )
 @click.option(
     "-j",
     "bz2_flag",
     is_flag=True,
     flag_value="tar.bz2",
-    help="Export as a .tar.bz2 archive",
+    help="Export as a .tar.bz2 archive.",
 )
 @click.option(
     "-z",
     "gz_flag",
     is_flag=True,
     flag_value="tar.gz",
-    help="Export as a .tar.gz archive",
+    help="Export as a .tar.gz archive.",
 )
 @click.option(
     "-t",
     "tar_flag",
     is_flag=True,
     flag_value="tar",
-    help="Export as an uncompressed .tar archive",
+    help="Export as an uncompressed .tar archive.",
 )
 @click.option(
     "-p",
     "zip_flag",
     is_flag=True,
     flag_value="zip",
-    help="Export as a .zip archive",
+    help="Export as a .zip archive.",
 )
 @click.option(
     "--format",

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -60,9 +60,13 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
     LOGGER.log(
         IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
     )
-    orig_head = backup.create_backup(
-        repo_root, f"Backing up state before rewinding to {revision}"
-    )
+    try:
+        orig_head = backup.create_backup(
+            repo_root, f"Backing up state before rewinding to {revision}"
+        )
+    except ValueError as already_backed_up:
+        LOGGER.warning("Nothing to back up: %s", already_backed_up)
+        orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
     _git.reset(repo_root, revision, hard=True)
     _git.reset(repo_root, orig_head, hard=False)

--- a/gsb/test/test_backup.py
+++ b/gsb/test/test_backup.py
@@ -83,10 +83,13 @@ class TestCreateBackup:
         repo = _git._repo(repo_root, new=False)
         assert repo.revparse_single(identifier).type == pygit2.GIT_OBJ_TAG
 
-    def test_raise_when_theres_nothing_new_to_backup(self, repo_root):
-        backup.create_backup(repo_root)
+    @pytest.mark.parametrize("tagged", (False, True), ids=("untagged", "tagged"))
+    def test_raise_when_theres_nothing_new_to_backup(self, repo_root, tagged):
+        backup.create_backup(repo_root, tag_message="You're it" if tagged else None)
         with pytest.raises(ValueError):
-            backup.create_backup(repo_root)
+            backup.create_backup(
+                repo_root, tag_message="You're still it" if tagged else None
+            )
 
     def test_tagging_a_previously_untagged_backup(self, repo_root):
         commit_hash = backup.create_backup(repo_root)

--- a/gsb/test/test_init.py
+++ b/gsb/test/test_init.py
@@ -223,7 +223,7 @@ class TestCLI:
         assert (root / ".git").exists()
 
     @pytest.mark.parametrize("where_is_root", ("absolute", "subdir", "pardir", "cwd"))
-    def test_name_resolves_successfully(self, root, where_is_root):
+    def test_name_resolves_successfully(self, root, where_is_root) -> None:
         (root / "subdir").mkdir()
         if where_is_root == "absolute":
             cwd: Path | None = None


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Fixes #32

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* `gsb backup --tag` will now fail if the current HEAD is already a tagged backup (meaning annotated tag), _e.g._
   > The current HEAD is already tagged as gsb2023.10.11+125502
* `gsb rewind` will also not create an unnecessary tag if the current state is already tagged
   * as would result in running two rewinds back-to-back, _a la_ https://github.com/OpenBagTwo/gsb/blob/42d2ed6ff927771f4a89f6f660f37f17f7533ea8/gsb/test/test_rewind.py#L89-L101
* This PR also includes some fixes stemming from the `gsb test` dogfooding
* I also performed some mypy and CLI help string nits 

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->

That quote above is from me running `gsb backup --tag` twice in a row on my own GSB-managed save repo

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->

## Note

This PR marks the **feature cutoff** for [v0.0.3](https://github.com/OpenBagTwo/gsb/milestone/5) (#36 / #40 is out of my hands and thus will likely get bumped to the next release). After this PR is merged, I'll be creating a release candidate and opening a staging branch which will include any additional documentation changes (read: #38) or bugfixes that get surfaced during release testing 


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
