### PR TITLE
Better handling for backups with "nothing to commit"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v3
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install linters
       run: |
         python -m pip install --upgrade pip
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py: ['3.12', '3.11']
+        py: ['3.13', '3.12', '3.11']
         # TODO: git
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 24.8.0
+  rev: 25.1.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+  rev: 6.0.1
   hooks:
   - id: isort
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.2
+  rev: v1.15.0
   hooks:
   - id: mypy
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.8.7
+  rev: 1.9.1
   hooks:
   - id: nbqa-isort
   - id: nbqa-mypy
@@ -26,7 +26,7 @@ repos:
   - id: pretty-format-yaml
     args: [--autofix]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: check-json
   - id: pretty-format-json

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 dependencies:
 - python=3.11
-- pygit2=1.12
+- pygit2=1.15
 - click=8.0
 - pathvalidate>=2.5
 - ipython>=8

--- a/gsb/backup.py
+++ b/gsb/backup.py
@@ -37,7 +37,8 @@ def create_backup(
     commit_message: str | None = None,
     parent: str | None = None,
     tag_name: str | None = None,
-) -> str:
+    raise_on_empty: bool = True,
+) -> str | None:
     """Create a new backup
 
     Parameters
@@ -61,12 +62,17 @@ def create_backup(
         By default, tag names are automatically generated. Use this argument to
         provide a custom tag name. This option is ignored when not creating
         a tag.
+    raise_on_empty : bool, optional
+        By default, if there is nothing to commit (and you're not tagging a
+        previously untagged commit), this method will raise
+        a ValueError. To simply log that there's nothing new to commit,
+        pass `raise_on_empty=False`.
 
     Returns
     -------
-    str
+    str or None
         An identifier for the backup in the form of either a commit hash or a
-        tag name
+        tag name (or `None` if no commit was generated)
 
     Raises
     ------
@@ -90,9 +96,10 @@ def create_backup(
         LOGGER.info("Changes committed with hash %s", identifier[:8])
         LOGGER.debug("Full hash: %s", identifier)
     except ValueError:
-        if not tag_message:
+        if not tag_message and raise_on_empty:
             raise
-        LOGGER.info("Nothing new to commit--all files are up-to-date.")
+        LOGGER.warning("Nothing new to commit--all files are up-to-date.")
+        identifier = None
     if tag_message:
         head = _git.show(repo_root, "HEAD")
         for tag in _git.get_tags(repo_root, annotated_only=True):

--- a/gsb/backup.py
+++ b/gsb/backup.py
@@ -37,8 +37,7 @@ def create_backup(
     commit_message: str | None = None,
     parent: str | None = None,
     tag_name: str | None = None,
-    raise_on_empty: bool = True,
-) -> str | None:
+) -> str:
     """Create a new backup
 
     Parameters
@@ -62,11 +61,6 @@ def create_backup(
         By default, tag names are automatically generated. Use this argument to
         provide a custom tag name. This option is ignored when not creating
         a tag.
-    raise_on_empty : bool, optional
-        By default, if there is nothing to commit (and you're not tagging a
-        previously untagged commit), this method will raise
-        a ValueError. To simply log that there's nothing new to commit,
-        pass `raise_on_empty=False`.
 
     Returns
     -------
@@ -96,10 +90,9 @@ def create_backup(
         LOGGER.info("Changes committed with hash %s", identifier[:8])
         LOGGER.debug("Full hash: %s", identifier)
     except ValueError:
-        if not tag_message and raise_on_empty:
+        if not tag_message:
             raise
-        LOGGER.warning("Nothing new to commit--all files are up-to-date.")
-        identifier = None
+        LOGGER.info("Nothing new to commit--all files are up-to-date.")
     if tag_message:
         head = _git.show(repo_root, "HEAD")
         for tag in _git.get_tags(repo_root, annotated_only=True):

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -77,6 +77,12 @@ def _subcommand_init(command: Callable) -> Callable:
 
 
 @click.option(
+    "--ignore-empty",
+    "-i",
+    is_flag=True,
+    help="Do not return an error code if there's nothing to commit",
+)
+@click.option(
     "--tag",
     type=str,
     help='Specify a description for this backup and "tag" it for future reference.',
@@ -98,7 +104,13 @@ def _subcommand_init(command: Callable) -> Callable:
     metavar="[SAVE_PATH]",
 )
 @_subcommand_init
-def backup(repo_root: Path, path_as_arg: Path | None, tag: str | None, combine: int):
+def backup(
+    repo_root: Path,
+    path_as_arg: Path | None,
+    tag: str | None,
+    combine: int,
+    ignore_empty: bool,
+):
     """Create a new backup."""
     parent_hash = None
     if combine == 1:
@@ -143,7 +155,12 @@ def backup(repo_root: Path, path_as_arg: Path | None, tag: str | None, combine: 
             LOGGER.log(IMPORTANT, "(no backups to combine)")
         parent_hash = last_tag["identifier"]
 
-    backup_.create_backup(path_as_arg or repo_root, tag, parent=parent_hash)
+    backup_.create_backup(
+        path_as_arg or repo_root,
+        tag,
+        parent=parent_hash,
+        raise_on_empty=not ignore_empty,
+    )
 
 
 @click.option(

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -80,7 +80,10 @@ def _subcommand_init(command: Callable) -> Callable:
     "--ignore-empty",
     "-i",
     is_flag=True,
-    help="Do not return an error code if there's nothing to commit",
+    help=(
+        "Do not return an error code if there's nothing to commit"
+        " (this flag only applies for untagged backups)"
+    ),
 )
 @click.option(
     "--tag",

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -155,12 +155,17 @@ def backup(
             LOGGER.log(IMPORTANT, "(no backups to combine)")
         parent_hash = last_tag["identifier"]
 
-    backup_.create_backup(
-        path_as_arg or repo_root,
-        tag,
-        parent=parent_hash,
-        raise_on_empty=not ignore_empty,
-    )
+    try:
+        backup_.create_backup(
+            path_as_arg or repo_root,
+            tag,
+            parent=parent_hash,
+        )
+    except ValueError as nothing_to_commit:
+        if ignore_empty:
+            LOGGER.warning("Nothing to commit")
+        else:
+            raise nothing_to_commit
 
 
 @click.option(

--- a/gsb/fastforward.py
+++ b/gsb/fastforward.py
@@ -59,13 +59,12 @@ def rewrite_history(repo_root: Path, starting_point: str, *revisions: str) -> st
             revision = tag_lookup[revision]  # type: ignore[index]
         new_history.append(revision)
 
-    try:
-        head = backup.create_backup(repo_root)
+    head = backup.create_backup(repo_root, raise_on_empty=False)
+    if head:
         LOGGER.log(IMPORTANT, "Unsaved changes have been backed up as %s", head[:8])
         new_history.append(_git.show(repo_root, head))
-    except ValueError:
-        # nothing to back up
-        pass
+    else:
+        head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
     try:
         branch_name = dt.datetime.now().strftime("gsb_rebase_%Y.%m.%d+%H%M%S")

--- a/gsb/fastforward.py
+++ b/gsb/fastforward.py
@@ -76,33 +76,47 @@ def rewrite_history(repo_root: Path, starting_point: str, *revisions: str) -> st
                 case _git.Commit():
                     _git.reset(repo_root, revision.hash, hard=True)
                     _git.reset(repo_root, head, hard=False)
-                    new_hash = _git.commit(
-                        repo_root,
-                        message=(
-                            revision.message + "\n\n" + f"rebase of {revision.hash}"
-                        ),
-                        timestamp=revision.timestamp,
-                    ).hash
-                    head = new_hash
+                    try:
+                        new_hash = _git.commit(
+                            repo_root,
+                            message=(
+                                revision.message + "\n\n" + f"rebase of {revision.hash}"
+                            ),
+                            timestamp=revision.timestamp,
+                        ).hash
+                        head = new_hash
+                    except ValueError:  # nothing to commit
+                        # identical to the last revision, so fuhgeddaboudit
+                        pass
                 case _git.Tag():
                     _git.reset(repo_root, revision.target.hash, hard=True)
                     _git.reset(repo_root, head, hard=False)
-                    new_hash = _git.commit(
-                        repo_root,
-                        message=(
-                            (revision.annotation or revision.name)
-                            + "\n\n"
-                            + f"rebase of {revision.target.hash}"
-                            + f' ("{revision.target.message.strip()}")'
-                        ),
-                        timestamp=revision.target.timestamp,
-                    ).hash
+                    try:
+                        new_hash = _git.commit(
+                            repo_root,
+                            message=(
+                                (revision.annotation or revision.name)
+                                + "\n\n"
+                                + f"rebase of {revision.target.hash}"
+                                + f' ("{revision.target.message.strip()}")'
+                            ),
+                            timestamp=revision.target.timestamp,
+                        ).hash
+                    except ValueError:  # nothing to commit
+                        LOGGER.warning(
+                            "Backup %s is identical to %s",
+                            revision.name,
+                            head,
+                        )
+                        new_hash = head
                     tags_to_update.append((revision, new_hash))
                     head = new_hash
+
                 case _:  # pragma: no cover
                     raise NotImplementedError(
                         f"Don't know how to handle revision of type {type(revision)}"
                     )
+
         for tag, target in tags_to_update:
             _git.delete_tag(repo_root, tag.name)
             _git.tag(repo_root, tag.name, tag.annotation, target=target)

--- a/gsb/fastforward.py
+++ b/gsb/fastforward.py
@@ -59,11 +59,11 @@ def rewrite_history(repo_root: Path, starting_point: str, *revisions: str) -> st
             revision = tag_lookup[revision]  # type: ignore[index]
         new_history.append(revision)
 
-    head = backup.create_backup(repo_root, raise_on_empty=False)
-    if head:
+    try:
+        head = backup.create_backup(repo_root)
         LOGGER.log(IMPORTANT, "Unsaved changes have been backed up as %s", head[:8])
         new_history.append(_git.show(repo_root, head))
-    else:
+    except ValueError:  # no unsaved changes
         head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
     try:

--- a/gsb/history.py
+++ b/gsb/history.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import logging
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -87,10 +88,12 @@ def get_history(
         If called with `return_parent=True` `get_history` and the earliest commit
         had no parent (being the initial commit, itself).
     """
-    tag_lookup = {
-        tag.target: tag for tag in _git.get_tags(repo_root, annotated_only=True)
-    }
-    LOGGER.debug("Retrieved %s tags", len(tag_lookup))
+    tag_lookup = defaultdict(list)
+    tag_count = 0
+    for tag in _git.get_tags(repo_root, annotated_only=True):
+        tag_lookup[tag.target].append(tag)
+        tag_count += 1
+    LOGGER.debug("Retrieved %s tags", tag_count)
 
     revisions: list[Revision] = []
     defer_break = False
@@ -100,13 +103,25 @@ def get_history(
                 defer_break = True
             else:
                 break
-        if tag := tag_lookup.get(commit):
+        if tags := tag_lookup.get(commit):
             if since_last_tagged_backup:
                 break
             tagged = True
-            identifier = tag.name
-            is_gsb = tag.gsb if tag.gsb is not None else commit.gsb
-            description = tag.annotation or commit.message
+            for tag in reversed(tags):
+                identifier = tag.name
+                is_gsb = tag.gsb if tag.gsb is not None else commit.gsb
+                description = tag.annotation or commit.message
+                if is_gsb or include_non_gsb:
+                    revisions.append(
+                        {
+                            "identifier": identifier,
+                            "commit_hash": commit.hash,
+                            "description": description.strip(),
+                            "timestamp": commit.timestamp,
+                            "tagged": tagged,
+                            "gsb": is_gsb,
+                        }
+                    )
         else:
             if tagged_only and not always_include_latest:
                 continue
@@ -114,18 +129,18 @@ def get_history(
             identifier = commit.hash[:8]
             is_gsb = commit.gsb
             description = commit.message
-        if not include_non_gsb and not is_gsb and not always_include_latest:
-            continue
-        revisions.append(
-            {
-                "identifier": identifier,
-                "commit_hash": commit.hash,
-                "description": description.strip(),
-                "timestamp": commit.timestamp,
-                "tagged": tagged,
-                "gsb": is_gsb,
-            }
-        )
+            if not include_non_gsb and not is_gsb and not always_include_latest:
+                continue
+            revisions.append(
+                {
+                    "identifier": identifier,
+                    "commit_hash": commit.hash,
+                    "description": description.strip(),
+                    "timestamp": commit.timestamp,
+                    "tagged": tagged,
+                    "gsb": is_gsb,
+                }
+            )
         if always_include_latest:
             if defer_break:
                 break

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -61,12 +61,13 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
     LOGGER.log(
         IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
     )
-    try:
-        orig_head = backup.create_backup(
-            repo_root, f"Backing up state before rewinding to {revision}"
-        )
-    except ValueError as already_backed_up:
-        LOGGER.warning("Nothing to back up: %s", already_backed_up)
+
+    orig_head = backup.create_backup(
+        repo_root,
+        f"Backing up state before rewinding to {revision}",
+        raise_on_empty=False,
+    )
+    if not orig_head:  # nothing to back up
         orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
     _git.reset(repo_root, revision, hard=True)
@@ -77,4 +78,4 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
         repo_root,
         f"Restored to {revision}",
         tag_name=generate_restore_tag_name(revision),
-    )
+    )  # type: ignore[return-value]

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -62,10 +62,10 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
         IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
     )
     try:
-        orig_head: str = backup.create_backup(
+        orig_head = backup.create_backup(
             repo_root,
             f"Backing up state before rewinding to {revision}",
-        )  # type: ignore[assignment]
+        )
     except ValueError:  #  nothing to back up
         orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
@@ -77,4 +77,4 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
         repo_root,
         f"Restored to {revision}",
         tag_name=generate_restore_tag_name(revision),
-    )  # type: ignore[return-value]
+    )

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -61,13 +61,12 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
     LOGGER.log(
         IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
     )
-
-    orig_head = backup.create_backup(
-        repo_root,
-        f"Backing up state before rewinding to {revision}",
-        raise_on_empty=False,
-    )
-    if not orig_head:  # nothing to back up
+    try:
+        orig_head: str = backup.create_backup(
+            repo_root,
+            f"Backing up state before rewinding to {revision}",
+        )  # type: ignore[assignment]
+    except ValueError:  #  nothing to back up
         orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
     _git.reset(repo_root, revision, hard=True)

--- a/gsb/test/test_backup.py
+++ b/gsb/test/test_backup.py
@@ -88,9 +88,29 @@ class TestCreateBackup:
     def test_raise_when_theres_nothing_new_to_backup(self, repo_root, tagged):
         backup.create_backup(repo_root, tag_message="You're it" if tagged else None)
         with pytest.raises(ValueError):
+            # tagged will raise because tag is already tagged
+            # untagged will raise by default
             backup.create_backup(
                 repo_root, tag_message="You're still it" if tagged else None
             )
+
+    def test_do_nothing_on_empty_if_told_to_ignore(self, repo_root):
+        backup.create_backup(repo_root)
+
+        last_revision = get_history(
+            repo_root, tagged_only=False, include_non_gsb=True, limit=1
+        )[0]["identifier"]
+
+        _ = backup.create_backup(
+            repo_root,
+            raise_on_empty=False,
+        )
+        assert [
+            revision["identifier"]
+            for revision in get_history(
+                repo_root, tagged_only=False, include_non_gsb=True, limit=1
+            )
+        ] == [last_revision]
 
     def test_tagging_a_previously_untagged_backup(self, repo_root):
         commit_hash = backup.create_backup(repo_root)
@@ -135,6 +155,20 @@ class TestCLI:
             len(prior_commits) + 1,
             len(prior_tags),
         )
+
+    @pytest.mark.parametrize("ignore_empty", (None, "-i", "--ignore-empty"))
+    def test_backup_fails_when_nothing_to_commit(
+        self, repo_root, prior_commits, prior_tags, ignore_empty
+    ):
+        subprocess.run(["gsb", "backup"], cwd=repo_root)
+
+        args = ["gsb", "backup"]
+        if ignore_empty:
+            args.append(ignore_empty)
+        result = subprocess.run(args, cwd=repo_root)
+        assert (result.returncode == 0) == (ignore_empty is not None)
+
+        assert len(list(_git.log(repo_root))) == len(prior_commits) + 1
 
     @pytest.mark.parametrize("how", ("by_argument", "by_option"))
     def test_passing_in_a_custom_root(self, repo_root, how, prior_commits):

--- a/gsb/test/test_backup.py
+++ b/gsb/test/test_backup.py
@@ -94,24 +94,6 @@ class TestCreateBackup:
                 repo_root, tag_message="You're still it" if tagged else None
             )
 
-    def test_do_nothing_on_empty_if_told_to_ignore(self, repo_root):
-        backup.create_backup(repo_root)
-
-        last_revision = get_history(
-            repo_root, tagged_only=False, include_non_gsb=True, limit=1
-        )[0]["identifier"]
-
-        _ = backup.create_backup(
-            repo_root,
-            raise_on_empty=False,
-        )
-        assert [
-            revision["identifier"]
-            for revision in get_history(
-                repo_root, tagged_only=False, include_non_gsb=True, limit=1
-            )
-        ] == [last_revision]
-
     def test_tagging_a_previously_untagged_backup(self, repo_root):
         commit_hash = backup.create_backup(repo_root)
         tag_name = backup.create_backup(repo_root, "You're it")

--- a/gsb/test/test_delete.py
+++ b/gsb/test/test_delete.py
@@ -8,6 +8,7 @@ import pytest
 from gsb import _git, fastforward
 from gsb.backup import create_backup
 from gsb.history import get_history
+from gsb.onboard import create_repo
 from gsb.rewind import restore_backup
 
 
@@ -65,6 +66,34 @@ class TestDeleteBackups:
             revision["identifier"]
             for revision in get_history(root, since=jurassic_timestamp)
         ] == ["gsb1.3", "gsb1.2"]
+
+    def test_deleting_a_backup_resulting_in_two_identical_backups(self, tmp_path):
+        root = tmp_path / "ping-pong"
+        root.mkdir(parents=True)
+
+        state_file = root / "state.txt"
+
+        create_repo(root, state_file.name)
+
+        state_file.write_text("ping")
+        create_backup(root, "Ping", tag_name="v1")
+
+        state_file.write_text("pong")
+        create_backup(root, "Pong", tag_name="v2")
+
+        state_file.write_text("ping")
+        create_backup(root, "Ping again", tag_name="v3")
+
+        state_file.write_text("pong")
+        create_backup(root, "Pong again", tag_name="v4")
+
+        fastforward.delete_backups(root, "v2")
+
+        assert [revision["identifier"] for revision in get_history(root)] == [
+            "v4",
+            "v3",
+            "v1",
+        ]
 
     def test_deleting_multiple_backups(self, root, all_backups):
         _git.reset(root, "gsb1.3", hard=True)

--- a/gsb/test/test_delete.py
+++ b/gsb/test/test_delete.py
@@ -67,33 +67,74 @@ class TestDeleteBackups:
             for revision in get_history(root, since=jurassic_timestamp)
         ] == ["gsb1.3", "gsb1.2"]
 
-    def test_deleting_a_backup_resulting_in_two_identical_backups(self, tmp_path):
-        root = tmp_path / "ping-pong"
-        root.mkdir(parents=True)
+    class TestBackupDeletionCreatingDegeneracy:
 
-        state_file = root / "state.txt"
+        def test_redundant_commits_are_skipped(self, tmp_path):
+            root = tmp_path / "ping-pong"
+            root.mkdir(parents=True)
 
-        create_repo(root, state_file.name)
+            state_file = root / "state.txt"
 
-        state_file.write_text("ping")
-        create_backup(root, "Ping", tag_name="v1")
+            create_repo(root, state_file.name)
 
-        state_file.write_text("pong")
-        create_backup(root, "Pong", tag_name="v2")
+            state_file.write_text("ping")
+            v1 = create_backup(root)
 
-        state_file.write_text("ping")
-        create_backup(root, "Ping again", tag_name="v3")
+            state_file.write_text("pong")
+            v2 = create_backup(root)
 
-        state_file.write_text("pong")
-        create_backup(root, "Pong again", tag_name="v4")
+            state_file.write_text("ping")
+            v3 = create_backup(root)
 
-        fastforward.delete_backups(root, "v2")
+            state_file.write_text("pong")
+            v4 = create_backup(root)
 
-        assert [revision["identifier"] for revision in get_history(root)] == [
-            "v4",
-            "v3",
-            "v1",
-        ]
+            fastforward.delete_backups(root, v2)
+
+            new_history = [
+                revision for revision in get_history(root, tagged_only=False)
+            ]
+            assert v4 in new_history[0]["description"]
+            assert new_history[1]["commit_hash"] == v1
+
+        @pytest.fixture
+        def setup(self, tmp_path, caplog):
+            root = tmp_path / "ping-pong"
+            root.mkdir(parents=True)
+
+            state_file = root / "state.txt"
+
+            create_repo(root, state_file.name)
+
+            state_file.write_text("ping")
+            create_backup(root, "Ping", tag_name="v1")
+
+            state_file.write_text("pong")
+            create_backup(root, "Pong", tag_name="v2")
+
+            state_file.write_text("ping")
+            create_backup(root, "Ping again", tag_name="v3")
+
+            state_file.write_text("pong")
+            create_backup(root, "Pong again", tag_name="v4")
+
+            caplog.clear()
+            with caplog.at_level(logging.WARNING):
+                fastforward.delete_backups(root, "v2")
+
+            yield root, caplog.records
+
+        def test_redundant_tags_are_both_preserved(self, setup):
+            root, _ = setup
+
+            assert [
+                revision["identifier"]
+                for revision in get_history(root, tagged_only=False)
+            ][:-1] == ["v4", "v3", "v1"]
+
+        def test_redundant_tags_produce_warnings(self, setup):
+            _, records = setup
+            assert records[-1].message.startswith("Backup v3 is identical to")
 
     def test_deleting_multiple_backups(self, root, all_backups):
         _git.reset(root, "gsb1.3", hard=True)


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Addresses #55 and #59

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Adds a new flag: `gsb backup --ignore-empty` that will return a 0 exit code even if there's nothing to commit
  * Note that this is **only** for non-tagged commits.
* Fixes behavior where deleting a backup between two identical backups fails
  * In such an event, no new commits will be generated, but if the backups are tagged, they will _both_ point to the shared commit

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->


<!--- Un-comment this section if this is still a work in progress. When doing
      so, please be sure to add (WIP), (Draft) or (DNM) in the PR title and
      open this PR as a draft

## To Do

--->


## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
* Auto-updated pre-commit and autolinted with the bumped hooks
* Updated pull request workflow to test against Python 3.13
* Added unit test explicitly to cover several permutations of #59
* Navigated to one of my gsb-managed backups and did the following:
   ```bash
   $ git staus
   On branch gsb
   nothing to commit, working tree clean
   $ gsb backup || echo "Error!"
   Nothing to commit
   Error!
   $ gsb backup -i || echo "Error!"
   Nothing to commit
   ```

## PR Type
<!--- Check all that apply --->
- [ ] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
