### PR TITLE
Add more functionality to rewind

### DIFF
--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -265,6 +265,11 @@ def history(
     help="Also revert the GSB configuration files (including .gitignore)",
 )
 @click.option(
+    "--delete-original",
+    is_flag=True,
+    help="Delete the original backup (incompatible with --hard)",
+)
+@click.option(
     "--hard",
     is_flag=True,
     help=(
@@ -279,10 +284,17 @@ def history(
 )
 @_subcommand_init
 def rewind(
-    repo_root: Path, revision: str | None, hard: bool, include_gsb_settings: bool
+    repo_root: Path,
+    revision: str | None,
+    hard: bool,
+    delete_original: bool,
+    include_gsb_settings: bool,
 ):
     """Restore a backup to the specified REVISION."""
     if hard:
+        if delete_original:
+            LOGGER.error("--delete-original and --hard cannot be used together")
+            sys.exit(1)
         if revision is None:
             revision = history_.get_history(
                 repo_root, tagged_only=False, include_non_gsb=True, limit=1
@@ -294,6 +306,8 @@ def rewind(
         rewind_.restore_backup(
             repo_root, revision, keep_gsb_files=not include_gsb_settings, hard=hard
         )
+        if delete_original:
+            fastforward.delete_backups(repo_root, revision)
     except ValueError as whats_that:
         LOGGER.error(whats_that)
         sys.exit(1)

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -264,24 +264,42 @@ def history(
     is_flag=True,
     help="Also revert the GSB configuration files (including .gitignore)",
 )
+@click.option(
+    "--hard",
+    is_flag=True,
+    help=(
+        "Discard any changes (backed up or no)"
+        " since the specified (default: latest) revision"
+    ),
+)
 @click.argument(
     "revision",
     type=str,
     required=False,
 )
 @_subcommand_init
-def rewind(repo_root: Path, revision: str | None, include_gsb_settings: bool):
+def rewind(
+    repo_root: Path, revision: str | None, hard: bool, include_gsb_settings: bool
+):
     """Restore a backup to the specified REVISION."""
+    if hard:
+        if revision is None:
+            revision = history_.get_history(
+                repo_root, tagged_only=False, include_non_gsb=True, limit=1
+            )[0]["identifier"]
+        _enumerate_revisions_to_be_discarded(repo_root, revision)
     if revision is None:
         revision = _prompt_for_a_recent_revision(repo_root)
     try:
-        rewind_.restore_backup(repo_root, revision, not include_gsb_settings)
+        rewind_.restore_backup(
+            repo_root, revision, keep_gsb_files=not include_gsb_settings, hard=hard
+        )
     except ValueError as whats_that:
         LOGGER.error(whats_that)
         sys.exit(1)
 
 
-def _prompt_for_a_recent_revision(repo_root) -> str:
+def _prompt_for_a_recent_revision(repo_root: Path) -> str:
     """Select a recent revision from a prompt"""
     LOGGER.log(IMPORTANT, "Here is a list of recent backups:")
     revisions = history_.show_history(repo_root, limit=10)
@@ -326,6 +344,39 @@ def _prompt_for_a_recent_revision(repo_root) -> str:
     if choice.strip() in [str(i + 1) for i in range(len(revisions))]:
         return revisions[int(choice.strip()) - 1]["identifier"]
     return choice
+
+
+def _enumerate_revisions_to_be_discarded(repo_root: Path, restore_point: str) -> None:
+    """List all the backups to be deleted by a hard restore to the restore-point,
+    then ask the user for confirmation"""
+
+    # figure out how far back this is in the history
+    break_point = _git.show(repo_root, restore_point)
+    if isinstance(break_point, _git.Tag):
+        break_point = break_point.target
+    limit = 0
+    for revision in _git.log(repo_root):
+        if revision == break_point:
+            break
+        limit += 1
+    else:  # pragma: no-cover
+        LOGGER.error("Specified revision is not in the current history. Cannot rewind.")
+        sys.exit(1)
+
+    LOGGER.warning("The following backups will be deleted:")
+    history_.show_history(
+        repo_root, numbering=None, tagged_only=False, include_non_gsb=True, limit=limit
+    )
+    LOGGER.warning("\nalong with any unsaved changes.\n")
+
+    confirmed: bool = click.confirm(
+        "Are you sure you wish to continue?",
+        default=False,
+        show_default=True,
+    )
+    if not confirmed:
+        LOGGER.error("Aborting.")
+        sys.exit(1)
 
 
 @click.argument(

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -267,7 +267,7 @@ def history(
 @click.option(
     "--delete-original",
     is_flag=True,
-    help="Delete the original backup (incompatible with --hard)",
+    help="Delete the original backup from the history (incompatible with --hard)",
 )
 @click.option(
     "--hard",

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -125,7 +125,7 @@ def backup(
             if "not enough values to unpack" in str(probably_not_enough_values):
                 LOGGER.error("Cannot combine with the very first backup.")
                 sys.exit(1)
-            raise probably_not_enough_values  # pragma: no-cover
+            raise probably_not_enough_values  # pragma: no cover
 
         LOGGER.log(IMPORTANT, "Combining with %s", combine_me["identifier"])
         if combine_me["tagged"]:
@@ -373,7 +373,7 @@ def _enumerate_revisions_to_be_discarded(repo_root: Path, restore_point: str) ->
         if revision == break_point:
             break
         limit += 1
-    else:  # pragma: no-cover
+    else:  # pragma: no cover
         LOGGER.error("Specified revision is not in the current history. Cannot rewind.")
         sys.exit(1)
 

--- a/gsb/cli.py
+++ b/gsb/cli.py
@@ -206,7 +206,7 @@ def init(
 
 
 @click.option(
-    "--include_non_gsb",
+    "--include-non-gsb",
     "-g",
     is_flag=True,
     help="Include backups created directly with Git / outside of gsb.",
@@ -260,7 +260,7 @@ def history(
 
 
 @click.option(
-    "--include_gsb_settings",
+    "--include-gsb-settings",
     is_flag=True,
     help="Also revert the GSB configuration files (including .gitignore)",
 )

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 
-from . import _git, backup
+from . import _git, backup, manifest
 from .logging import IMPORTANT
 
 LOGGER = logging.getLogger(__name__)
@@ -73,7 +73,9 @@ def restore_backup(
 
     orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
-    if not hard:
+    if hard:
+        _git.add(repo_root, manifest.Manifest.of(repo_root).patterns)
+    else:
         LOGGER.log(
             IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
         )

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -69,7 +69,7 @@ def restore_backup(
     ValueError
         If the specified revision does not exist
     """
-    _git.show(repo_root, revision)
+    _git.show(repo_root, revision)  # ensure revision exists
 
     orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
 
@@ -88,14 +88,18 @@ def restore_backup(
     _git.reset(repo_root, revision, hard=True)
     if keep_gsb_files:
         _git.checkout_files(repo_root, orig_head, backup.REQUIRED_FILES)
-    if not hard:
-        _git.reset(repo_root, orig_head, hard=False)
-
-    try:
-        return backup.create_backup(
-            repo_root,
-            f"Restored to {revision}",
-            tag_name=generate_restore_tag_name(revision),
-        )
-    except ValueError:
+    if hard:
+        try:  # on the off chance that the gsb files changed, commit them
+            backup.create_backup(
+                repo_root, commit_message="Cherry-picking changes to the gsb files"
+            )
+        except ValueError:  # this is actually the more likely outcome
+            pass
         return revision
+
+    _git.reset(repo_root, orig_head, hard=False)
+    return backup.create_backup(
+        repo_root,
+        f"Restored to {revision}",
+        tag_name=generate_restore_tag_name(revision),
+    )

--- a/gsb/rewind.py
+++ b/gsb/rewind.py
@@ -26,7 +26,9 @@ def generate_restore_tag_name(revision: str) -> str:
     return f"{backup.generate_tag_name()}.restore_of_{revision}"
 
 
-def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) -> str:
+def restore_backup(
+    repo_root: Path, revision: str, keep_gsb_files: bool = True, hard: bool = False
+) -> str:
     """Rewind to a previous backup state and create a new backup
 
     Parameters
@@ -39,15 +41,26 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
         By default, `.gsb_manifest` and `.gitignore` *will not* be restored
         (that is, the latest versions will be kept). To override this behavior,
         pass in `keep_gsb_files = False`.
+    hard : bool, optional
+        By default, any backups after the specified revision will be kept in
+        the history (with the specified restore point just copied to the top
+        of the stack). If you want to *fully erase* all progress after the
+        restore point (backed up or loose), pass in `hard = True` and then run
+        `git gc --aggressive --prune=now` afterward.
 
     Returns
     -------
     str
-        The tag name of the new restored backup
+        The name of the restored backup
 
     Notes
     -----
-    Before creating the backup, any un-backed up changes will first be backed up
+    - Before creating the backup, any un-backed up changes will first be backed up
+      unless `hard = True` is specified.
+    - When restoring with `hard = True`, **unsaved changes** to `.gsb_manifest`
+      and `.gitignore` will **not** be kept, even with `keep_gsb_files = True`.
+      Instead, the restored backup will contain the GSB files from the most
+      recent backup (tagged or otherwise).
 
     Raises
     ------
@@ -58,23 +71,31 @@ def restore_backup(repo_root: Path, revision: str, keep_gsb_files: bool = True) 
     """
     _git.show(repo_root, revision)
 
-    LOGGER.log(
-        IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
-    )
-    try:
-        orig_head = backup.create_backup(
-            repo_root,
-            f"Backing up state before rewinding to {revision}",
+    orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
+
+    if not hard:
+        LOGGER.log(
+            IMPORTANT, "Backing up any unsaved changes before rewinding to %s", revision
         )
-    except ValueError:  #  nothing to back up
-        orig_head = _git.show(repo_root, "HEAD").hash  # type: ignore[union-attr]
+        try:
+            orig_head = backup.create_backup(
+                repo_root,
+                f"Backing up state before rewinding to {revision}",
+            )
+        except ValueError:  #  nothing to back up
+            pass
 
     _git.reset(repo_root, revision, hard=True)
-    _git.reset(repo_root, orig_head, hard=False)
     if keep_gsb_files:
         _git.checkout_files(repo_root, orig_head, backup.REQUIRED_FILES)
-    return backup.create_backup(
-        repo_root,
-        f"Restored to {revision}",
-        tag_name=generate_restore_tag_name(revision),
-    )
+    if not hard:
+        _git.reset(repo_root, orig_head, hard=False)
+
+    try:
+        return backup.create_backup(
+            repo_root,
+            f"Restored to {revision}",
+            tag_name=generate_restore_tag_name(revision),
+        )
+    except ValueError:
+        return revision

--- a/gsb/test/test_history.py
+++ b/gsb/test/test_history.py
@@ -164,7 +164,7 @@ class TestCLI:
         ]
         assert backups == [last_backup, "2. gsb1.3", "3. gsb1.2"]
 
-    @pytest.mark.parametrize("flag", ("--include_non_gsb", "-g"))
+    @pytest.mark.parametrize("flag", ("--include-non-gsb", "-g"))
     def test_including_non_gsb(self, root, last_backup, flag):
         args = ["gsb", "history", flag]
 

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -370,7 +370,10 @@ class TestCLI:
         old_history = get_history(repo, tagged_only=False)
 
         _ = subprocess.run(
-            ["gsb", "rewind", "--hard"], cwd=repo, capture_output=False, input="y\n"
+            ["gsb", "rewind", "--hard"],
+            cwd=repo,
+            capture_output=False,
+            input="y\n".encode(),
         )
 
         new_history = get_history(repo, tagged_only=False)
@@ -380,9 +383,12 @@ class TestCLI:
 
     def test_hard_rewind_warns_about_discarding_changes(self, repo):
         result = subprocess.run(
-            ["gsb", "rewind", "--hard"], cwd=repo, capture_output=True, input="n\n"
+            ["gsb", "rewind", "--hard"],
+            cwd=repo,
+            capture_output=True,
+            input="n\n".encode(),
         )
-        assert "You have unsaved change" in result.stderr.decode()
+        assert "any unsaved change" in result.stderr.decode()
 
         assert (repo / "save" / "data.txt").read_text() == "Sneaky sneaky\n"
 
@@ -391,7 +397,8 @@ class TestCLI:
             ["gsb", "rewind", "--hard", "gsb2023.07.12"],
             cwd=repo,
             capture_output=True,
-            input="n\n",
+            input="n\n".encode(),
         )
 
         assert "gsb2023.07.13" in result.stderr.decode()
+        assert "gsb2023.07.12" not in result.stderr.decode()

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -402,3 +402,24 @@ class TestCLI:
 
         assert "gsb2023.07.13" in result.stderr.decode()
         assert "gsb2023.07.12" not in result.stderr.decode()
+
+    def test_delete_original(self, repo):
+        backup.create_backup(repo, tag_message="Saving any unsaved changes")
+        old_history = [
+            revision["identifier"] for revision in get_history(repo, tagged_only=False)
+        ]
+
+        _ = subprocess.run(
+            ["gsb", "rewind", "gsb2023.07.12", "--delete-original"],
+            cwd=repo,
+            capture_output=True,
+        )
+        new_history = [
+            revision["identifier"] for revision in get_history(repo, tagged_only=False)
+        ]
+
+        assert (
+            new_history[1:]
+            == old_history[: old_history.index("gsb2023.07.12")]
+            + old_history[old_history.index("gsb2023.07.12") + 1 :]
+        )

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -72,7 +72,7 @@ class TestRestoreBackup:
         )
 
     def test_restores_file_content_to_a_previous_commit(self, repo):
-        commit_two = list(get_history(repo, tagged_only=False))[-4]
+        commit_two = get_history(repo, tagged_only=False)[-4]
         assert not commit_two["identifier"].startswith("gsb")  # not a tag
         rewind.restore_backup(repo, commit_two["identifier"])
         assert (repo / "save" / "data.txt").read_text() == "2\n"
@@ -92,7 +92,7 @@ class TestRestoreBackup:
         assert (repo / "save" / "data.txt").read_text() == "Sneaky sneaky\n"
         rewind.restore_backup(repo, last_backup["identifier"])
         assert (repo / "save" / "data.txt").read_text() == "9\n"
-        all_backups = list(get_history(repo, tagged_only=False))
+        all_backups = get_history(repo, tagged_only=False)
 
         assert all_backups[2] == last_backup  # because reverse-chronological
 
@@ -161,6 +161,53 @@ class TestRestoreBackup:
         time.sleep(1)  # blergh
         rewind.restore_backup(repo_root, restore_point["identifier"])
         assert not (repo_root / "furniture" / "sofa").exists()
+
+    def test_hard_rewind_does_not_keep_unsaved_changes(self, repo):
+
+        old_history = get_history(repo, tagged_only=False)
+        rewind.restore_backup(repo, old_history[0]["identifier"], hard=True)
+        new_history = get_history(repo, tagged_only=False)
+
+        assert (repo / "save" / "data.txt").read_text() == "9\n"
+        assert new_history == old_history
+
+    @pytest.mark.parametrize("keep_gsb_files", (True, False))
+    def test_hard_rewind_keeps_committed_gsb_file_changes_by_default(
+        self, repo, keep_gsb_files
+    ):
+        kwargs = {"hard": True}
+        if not keep_gsb_files:
+            kwargs["keep_gsb_files"] = keep_gsb_files
+
+        old_history = get_history(repo, tagged_only=False)
+
+        with (repo / ".gitignore").open("a") as gitignore_file:
+            gitignore_file.write("\nboop\n")
+
+        _git.add(repo, (".gitignore",))
+        _git.commit(repo, "Not even a GSB backup")
+
+        rewind.restore_backup(repo, old_history[0]["identifier"], **kwargs)
+        new_history = get_history(repo, tagged_only=False)
+
+        assert (
+            (repo / ".gitignore").read_text().splitlines()[-1] == "boop"
+        ) == keep_gsb_files
+        if keep_gsb_files:
+            assert new_history[1:] == old_history
+        else:
+            assert new_history == old_history
+
+    def test_hard_rewinding_to_older_backups(self, repo):
+        old_history = [
+            revision["commit_hash"] for revision in get_history(repo, tagged_only=False)
+        ]
+        rewind.restore_backup(repo, old_history[5], hard=True)
+        new_history = [
+            revision["commit_hash"] for revision in get_history(repo, tagged_only=False)
+        ]
+
+        assert new_history == old_history[5:]
 
 
 class TestCLI:
@@ -318,3 +365,33 @@ class TestCLI:
         )
 
         assert "# it's a comment" not in (repo / MANIFEST_NAME).read_text()
+
+    def test_hard_rewind_defaults_to_last_backup(self, repo):
+        old_history = get_history(repo, tagged_only=False)
+
+        _ = subprocess.run(
+            ["gsb", "rewind", "--hard"], cwd=repo, capture_output=False, input="y\n"
+        )
+
+        new_history = get_history(repo, tagged_only=False)
+
+        assert (repo / "save" / "data.txt").read_text() == "9\n"
+        assert new_history == old_history
+
+    def test_hard_rewind_warns_about_discarding_changes(self, repo):
+        result = subprocess.run(
+            ["gsb", "rewind", "--hard"], cwd=repo, capture_output=True, input="n\n"
+        )
+        assert "You have unsaved change" in result.stderr.decode()
+
+        assert (repo / "save" / "data.txt").read_text() == "Sneaky sneaky\n"
+
+    def test_hard_rewind_warns_about_the_backups_youre_deleting(self, repo):
+        result = subprocess.run(
+            ["gsb", "rewind", "--hard", "gsb2023.07.12"],
+            cwd=repo,
+            capture_output=True,
+            input="n\n",
+        )
+
+        assert "gsb2023.07.13" in result.stderr.decode()

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -359,7 +359,7 @@ class TestCLI:
             manifest.write("# it's a comment\n")
 
         _ = subprocess.run(
-            ["gsb", "rewind", "gsb2023.07.12", "--include_gsb_settings"],
+            ["gsb", "rewind", "gsb2023.07.12", "--include-gsb-settings"],
             cwd=repo,
             capture_output=False,
         )

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -171,6 +171,17 @@ class TestRestoreBackup:
         assert (repo / "save" / "data.txt").read_text() == "9\n"
         assert new_history == old_history
 
+    def test_hard_rewind_does_not_promote_untagged_backups(self, repo):
+        backup.create_backup(repo)
+
+        (repo / "save" / "data.txt").write_text("10\n")
+
+        old_head = get_history(repo, tagged_only=False, limit=1)[0]
+        rewind.restore_backup(repo, old_head["identifier"], hard=True)
+        new_head = get_history(repo, tagged_only=False, limit=1)[0]
+
+        assert new_head == old_head
+
     @pytest.mark.parametrize("keep_gsb_files", (True, False))
     def test_hard_rewind_keeps_committed_gsb_file_changes_by_default(
         self, repo, keep_gsb_files

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -414,12 +414,27 @@ class TestCLI:
             cwd=repo,
             capture_output=True,
         )
-        new_history = [
-            revision["identifier"] for revision in get_history(repo, tagged_only=False)
-        ]
+        new_history = []
+        for revision in get_history(repo, tagged_only=False):
+            if revision["tagged"]:
+                new_history.append(revision["identifier"])
+            elif "rebase of" in revision["description"]:
+                new_history.append(revision["description"].split(" ")[-1][:8])
+            else:
+                new_history.append(revision["identifier"])
 
         assert (
             new_history[1:]
             == old_history[: old_history.index("gsb2023.07.12")]
             + old_history[old_history.index("gsb2023.07.12") + 1 :]
         )
+
+    def test_delete_original_is_incompatible_with_hard(self, repo):
+        result = subprocess.run(
+            ["gsb", "rewind", "--hard", "gsb2023.07.12", "--delete-original"],
+            cwd=repo,
+            capture_output=True,
+            input="n\n".encode(),
+        )
+        assert result.returncode != 0
+        assert (repo / "save" / "data.txt").read_text() == "Sneaky sneaky\n"

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -369,12 +369,13 @@ class TestCLI:
     def test_hard_rewind_defaults_to_last_backup(self, repo):
         old_history = get_history(repo, tagged_only=False)
 
-        _ = subprocess.run(
+        result = subprocess.run(
             ["gsb", "rewind", "--hard"],
             cwd=repo,
             capture_output=False,
             input="y\n".encode(),
         )
+        assert result.returncode == 0
 
         new_history = get_history(repo, tagged_only=False)
 
@@ -409,11 +410,14 @@ class TestCLI:
             revision["identifier"] for revision in get_history(repo, tagged_only=False)
         ]
 
-        _ = subprocess.run(
+        result = subprocess.run(
             ["gsb", "rewind", "gsb2023.07.12", "--delete-original"],
             cwd=repo,
             capture_output=True,
         )
+
+        assert result.returncode == 0
+
         new_history = []
         for revision in get_history(repo, tagged_only=False):
             if revision["tagged"]:

--- a/gsb/test/test_rewind.py
+++ b/gsb/test/test_rewind.py
@@ -171,10 +171,17 @@ class TestRestoreBackup:
         assert (repo / "save" / "data.txt").read_text() == "9\n"
         assert new_history == old_history
 
+    def test_hard_rewind_deletes_untracked_files(self, repo):
+        restore_point = backup.create_backup(repo)
+
+        (repo / "save" / "fluffy.txt").write_text("doc\n")
+
+        rewind.restore_backup(repo, restore_point, hard=True)
+
+        assert not (repo / "save" / "fluffy.txt").exists()
+
     def test_hard_rewind_does_not_promote_untagged_backups(self, repo):
         backup.create_backup(repo)
-
-        (repo / "save" / "data.txt").write_text("10\n")
 
         old_head = get_history(repo, tagged_only=False, limit=1)[0]
         rewind.restore_backup(repo, old_head["identifier"], hard=True)


### PR DESCRIPTION
## Summary
<!--- One sentence summary of this PR. Can oftentimes just be a matter of linking
      to the issue number --->

Implements #60 and #47

## List of Changes
<!--- List out the changes introduced by this PR, permalinking
      (read: with commit hash) to the commit, file or section of code where
      that change was implemented --->

* Adds the command-line-flag `--hard` to `gsb rewind`, which is essentially the equivalent of a `git reset --hard HEAD` by default, and which can be used to erase all progress after the specified revision
* Adds the command-line-flag `--delete-original` to `gsb rewind`, which, upon restoring to a backup, will delete the original backup from the history
* Normalizes some command-line flags to use hyphens instead of underscores
* ed18c4b fixes some coverage exclusions

## Tech Debt and Other Concerns
<!--- Use this section to call out anything in the code (including stuff you
      discovered outside of your contributions!) that you think may cause
      issues either now or further down the road. These will need to be spun
      off into issues before the PR is closed but shouldn't impede you opening
      the PR and starting the review process --->

More validation absolutely needs to be done, but this is the last PR before I plan on creating a release candidate, so the validation will be performed there.

Technically I'm introducing a breaking change by going from `--include_non_gsb` to `--include-non-gsb`, but hey—we're pre 0.1 here.

## Validation Performed
<!--- What did you do to ensure that this change is behaving as intended? This
should start with unit tests, but it's usually a good idea to try running
the code in a real setting. Include screenshots if you'd like, but make sure to
remove any personal information you won't want to share --->
- Ran `gsb rewind --hard v0.0.4` on this repo, which indeed rewound the repo to the last release (before erroring out because it couldn't find a manifest)
- Ran `gsb rewind --hard` to discard unsaved changes on a GSB-managed repo. The changes were discarded, but it "promoted" the untagged release as `gsb2025.05.02+163558.restore_of_dbb22c14` which is... not the desired behavior
- Ran `gsb rewind --hard dbb22c14` to get rid of that tag, which worked... and then generated a new tag of its own

## To Do

- [x] It's fine for `gsb rewind --hard` to tag the last commit if it was previously untagged, but it should just get a regular tag, not a "restore_of" tag name.

## PR Type
<!--- Check all that apply --->
- [x] This PR introduces a breaking change (will
  [require a bump in the minor version](https://semver.org/))
- [ ] The changes in this PR are high urgency and necessitate a hotfix or patch
  release (will require rebasing off of `release`)
- [ ] This is a release (staging) PR (maintainer use only)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply.
      All bullets in this section are required to be checked off before the PR can
      be merged, but they don't need to be checked off before the PR is opened.
      If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read [the contributor's guide](https://openbagtwo.github.io/gsb/dev/contrib/)
- [x] I have run `mkdocs serve` locally and ensured that all API docs and
  changes I have made to the static pages are rendering correctly, with all links
  working
- [x] All tech debt concerns have been resolved, documented as issues, or otherwise
  accepted
- [x] I agree to license my contribution to this project under
  [the GNU Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html)
  <!--- If you wish to use a different compatible license, please edit the above--->


<!--- Adapted from https://github.com/stevemao/github-issue-templates --->
